### PR TITLE
Merging new changes for the atrial mesh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,11 +135,7 @@ perf.data*
 meshes/VF_20120221_toBlanca-newCGAL1.vtu
 meshes/human_500_new.alg
 meshes/human_800_new.alg
-meshes/atrial_mesh.alg
-meshes/atrial_mesh.fibers
-meshes/atrial_mesh.vtu
-meshes/atrial_mesh_sub.alg
-meshes/atrial_mesh_sub.fibers
+meshes/atrial_mesh*
 meshes/ModVent_PAP_500um.alg
 meshes/elizabeth*
 meshes/convertor.py

--- a/.local.vimrc
+++ b/.local.vimrc
@@ -1,8 +1,2 @@
 set makeprg=./build.sh
 set guioptions+=!
-
-let g:ale_linters_explicit = 1
-
-let b:ale_linters = ["gcc", "cppcheck", "flawfinder"]
-let b:ale_fixers = ['clangtidy', 'clang-format']
-

--- a/bsbash/build_functions.sh
+++ b/bsbash/build_functions.sh
@@ -527,3 +527,13 @@ ADD_SUBDIRECTORY() {
 	source build.sh
 	cd "$PREVIOUS_DIR" || exit
 }
+
+CHECK_CUSTOM_FILE() {
+	
+	CUSTOM_FILE=""
+
+	if [ -f "$1" ]; then
+		CUSTOM_FILE="$1"
+	fi
+
+}

--- a/example_configs/scv_mesh.ini
+++ b/example_configs/scv_mesh.ini
@@ -5,7 +5,7 @@
 [main]
 num_threads=4
 dt_pde=0.02
-simulation_time=0.02
+simulation_time=500
 abort_on_no_activity=false
 use_adaptivity=false
 
@@ -49,7 +49,7 @@ dt=0.02
 use_gpu=true
 gpu_id=0
 adaptive=false
-library_file=./shared_libs/libten_tusscher_3_endo.so
+library_file=./shared_libs/libten_tusscher_2004_mixed_endo_mid_epi.so
 
 [domain]
 name=SCV Mesh
@@ -67,7 +67,7 @@ x_limit = 9000
 main_function=stim_if_x_less_than
 
 [extra_data]
-main_function=set_extra_data_for_no_fibrosis
+main_function=set_extra_data_for_scv_mesh
 
 ;[stim_human]
 ;stim_file=meshes/stim.pts

--- a/src/common_types/common_types.h
+++ b/src/common_types/common_types.h
@@ -22,6 +22,9 @@ typedef float real;
 #define MALLOC_ONE_TYPE(type) (type *) malloc(sizeof(type))
 #define MALLOC_ARRAY_OF_TYPE(type, n) (type *) malloc(sizeof(type) * n)
 
+#define CALLOC_ONE_TYPE(type) (type *) calloc(1, sizeof(type))
+#define CALLOC_ARRAY_OF_TYPE(type, n) (type *) calloc(n, sizeof(type))
+
 typedef double real_cpu;
 
 enum simulation_status {

--- a/src/config/config_parser.c
+++ b/src/config/config_parser.c
@@ -16,9 +16,10 @@
 static const char *batch_opt_string = "c:h?";
 static const struct option long_batch_options[] = {{"config_file", required_argument, NULL, 'c'}};
 
-static const char *conversion_opt_string = "i:o:h?";
+static const char *conversion_opt_string = "i:o:v:h?";
 static const struct option long_conversion_options[] = {{"input", required_argument, NULL, 'i'},
-                                                        {"output", required_argument, NULL, 'o'}};
+                                                        {"output", required_argument, NULL, 'o'},
+                                                        {"value_index", required_argument, NULL, 'v'}};
 
 static const char *fiber_conversion_opt_string = "f:e:n:a:h?";
 static const struct option long_fiber_conversion_options[] = {{"fib", required_argument, NULL, 'f'},
@@ -225,6 +226,7 @@ struct conversion_options *new_conversion_options() {
     struct conversion_options *options = (struct conversion_options *)malloc(sizeof(struct conversion_options));
     options->input = NULL;
     options->output = NULL;
+	options->value_index = 6; //Value for the default position of V in your text format
     return options;
 };
 
@@ -971,6 +973,10 @@ void parse_conversion_options(int argc, char **argv, struct conversion_options *
         case 'o':
             user_args->output = strdup(optarg);
             break;
+		case 'v':
+            user_args->value_index = strtol(optarg, NULL, 10);
+            break;
+
         case 'h': /* fall-through is intentional */
         case '?':
             display_conversion_usage(argv);

--- a/src/config/config_parser.h
+++ b/src/config/config_parser.h
@@ -169,6 +169,7 @@ struct visualization_options {
 struct conversion_options {
     char *input;
     char *output;
+	uint32_t value_index;
 };
 
 struct fibers_conversion_options {

--- a/src/domains_library/domain.c
+++ b/src/domains_library/domain.c
@@ -415,7 +415,7 @@ SET_SPATIAL_DOMAIN(initialize_grid_scv_mesh) {
 				grid_cell->active = true;
 				int old_index = (int)mesh_points[index][3];
 
-				INITIALIZE_FIBROTIC_INFO(grid_cell);
+				INITIALIZE_SCV_INFO(grid_cell);
 
 				FIBROTIC(grid_cell) = (scar_or_border[old_index] == 2);
 				BORDER_ZONE(grid_cell) = (scar_or_border[old_index] == 1);
@@ -437,7 +437,6 @@ SET_SPATIAL_DOMAIN(initialize_grid_scv_mesh) {
 
     free(mesh_points);
 
-    // TODO: we need to sum the cell discretization here...
     the_grid->mesh_side_length.x = maxx;
     the_grid->mesh_side_length.y = maxy;
     the_grid->mesh_side_length.z = maxz;

--- a/src/domains_library/domain.c
+++ b/src/domains_library/domain.c
@@ -908,6 +908,160 @@ SET_SPATIAL_DOMAIN(initialize_grid_with_mouse_mesh) {
     return 1;
 }
 
+SET_SPATIAL_DOMAIN(initialize_grid_with_atrial_mesh_with_tissue_type) {
+
+    char *mesh_file = NULL;
+    GET_PARAMETER_STRING_VALUE_OR_REPORT_ERROR(mesh_file, config->config_data, "mesh_file");
+
+    real_cpu start_h = 500.0;
+    GET_PARAMETER_NUMERIC_VALUE_OR_USE_DEFAULT(real_cpu, start_h, config->config_data, "original_discretization");
+
+    real_cpu desired_h = 500.0;
+    GET_PARAMETER_NUMERIC_VALUE_OR_USE_DEFAULT(real_cpu, desired_h, config->config_data, "desired_discretization");
+
+    assert(the_grid);
+
+    // TODO: we should put this in the grid data again
+    //
+    // the_grid -> start_discretization.x = SAME_POINT3D{start_discretization};
+    //
+
+    // TODO: change this to the code above
+    char *tmp = shget(config->config_data, "desired_discretization");
+    shput_dup_value(config->config_data, "start_dx", tmp);
+    shput_dup_value(config->config_data, "start_dy", tmp);
+    shput_dup_value(config->config_data, "start_dz", tmp);
+
+    float cube_side = 128000;
+
+    int tmp_size = (int)(cube_side / 2);
+    int num_ref = 0;
+    while(tmp_size > start_h) {
+        tmp_size = tmp_size / 2;
+        num_ref++;
+    }
+
+    initialize_and_construct_grid(the_grid, POINT3D(cube_side, cube_side, cube_side));
+
+    refine_grid(the_grid, num_ref);
+
+    log_to_stdout_and_file("Loading Atrial Heart Mesh with discretization: %lf\n", the_grid->first_cell->discretization.x);
+
+    FILE *file = fopen(mesh_file, "r");
+
+    if(!file) {
+        log_to_stderr_and_file_and_exit("Error opening mesh described in %s!!\n", mesh_file);
+    }
+
+    int num_volumes = 514389;
+    GET_PARAMETER_NUMERIC_VALUE_OR_USE_DEFAULT(int, num_volumes, config->config_data, "num_volumes");
+
+    real_cpu **mesh_points = MALLOC_ARRAY_OF_TYPE(real_cpu *, num_volumes);
+    for(int i = 0; i < num_volumes; i++) {
+        mesh_points[i] = MALLOC_ARRAY_OF_TYPE(real_cpu, 4);
+
+        if(mesh_points[i] == NULL) {
+            log_to_stderr_and_file_and_exit("Failed to allocate memory\n");
+        }
+    }
+    real_cpu dummy;
+
+    real_cpu maxy = 0.0;
+    real_cpu maxz = 0.0;
+    real_cpu miny = DBL_MAX;
+    real_cpu minz = DBL_MAX;
+
+    int i = 0;
+
+	int *tissue_type = MALLOC_ARRAY_OF_TYPE(int, num_volumes);
+
+    while(i < num_volumes) {
+
+        fscanf(file, "%lf,%lf,%lf,%lf,%lf,%lf,%d\n", &mesh_points[i][0], &mesh_points[i][1], &mesh_points[i][2], &dummy, &dummy, &dummy, &tissue_type[i]);
+
+        if(mesh_points[i][1] > maxy)
+            maxy = mesh_points[i][1];
+        if(mesh_points[i][2] > maxz)
+            maxz = mesh_points[i][2];
+        if(mesh_points[i][1] < miny)
+            miny = mesh_points[i][1];
+        if(mesh_points[i][2] < minz)
+            minz = mesh_points[i][2];
+
+        mesh_points[i][4] = i; //This is the original volume position in the mesh file
+
+        i++;
+    }
+
+    sort_vector(mesh_points, num_volumes); // we need to sort because inside_mesh perform a binary search
+
+    real_cpu maxx = mesh_points[num_volumes - 1][0];
+    real_cpu minx = mesh_points[0][0];
+    int index;
+
+    int num_loaded = 0;
+
+    real_cpu x, y, z;
+
+    FOR_EACH_CELL(the_grid) {
+        x = cell->center.x;
+        y = cell->center.y;
+        z = cell->center.z;
+
+        if(x > maxx || y > maxy || z > maxz || x < minx || y < miny || z < minz) {
+            cell->active = false;
+        } else {
+            index = inside_mesh(mesh_points, x, y, z, 0, num_volumes - 1);
+
+            if(index != -1) {
+                cell->active = true;
+                cell->original_position_in_file = mesh_points[index][4];
+
+				INITIALIZE_SCV_INFO(cell);
+				TISSUE_TYPE(cell) = tissue_type[cell->original_position_in_file];
+
+                num_loaded++;
+
+            } else {
+                cell->active = false;
+            }
+        }
+    }
+
+    log_to_stdout_and_file("Read %d volumes from file: %s\n", num_loaded, mesh_file);
+
+    fclose(file);
+
+    // deallocate memory
+    for(int l = 0; l < num_volumes; l++) {
+        free(mesh_points[l]);
+    }
+
+    free(mesh_points);
+
+    if(num_loaded > 0) {
+        // TODO: we need to sum the cell discretization here...
+        the_grid->mesh_side_length.x = maxx;
+        the_grid->mesh_side_length.y = maxy;
+        the_grid->mesh_side_length.z = maxz;
+
+        log_to_stdout_and_file("Cleaning grid\n");
+
+        for(i = 0; i < num_ref; i++) {
+            derefine_grid_inactive_cells(the_grid);
+        }
+    }
+
+	int num_refs = (int)(start_h/desired_h) - 1;
+	
+	if(num_refs > 0)
+		refine_grid(the_grid, num_refs);
+
+    free(mesh_file);
+
+    return num_loaded;
+}
+
 SET_SPATIAL_DOMAIN(initialize_grid_with_atrial_mesh) {
 
     char *mesh_file = NULL;

--- a/src/extra_data_library/extra_data.c
+++ b/src/extra_data_library/extra_data.c
@@ -361,3 +361,25 @@ SET_EXTRA_DATA(set_extra_data_for_benchmark) {
 
     return (void*)initial_conditions;
 }
+
+SET_EXTRA_DATA(set_extra_data_for_scv_mesh) {
+
+	uint32_t num_active_cells = the_grid->num_active_cells;
+
+	*extra_data_size = sizeof(uint32_t)*(num_active_cells);
+
+	uint32_t *mapping = (uint32_t*)malloc(*extra_data_size);
+
+	struct cell_node ** ac = the_grid->active_cells;
+
+	int i;
+
+	OMP(parallel for)
+	for (i = 0; i < num_active_cells; i++) {
+		mapping[i] = TISSUE_TYPE(ac[i]); //endo 0; mid  1; epi  2
+	}
+
+	return (void*)mapping;
+
+}
+

--- a/src/extra_data_library/extra_mixed_models.c
+++ b/src/extra_data_library/extra_mixed_models.c
@@ -10,7 +10,7 @@ SET_EXTRA_DATA (set_mixed_model_if_x_less_than)
 {
     uint32_t num_active_cells = the_grid->num_active_cells;
 
-    *extra_data_size = sizeof(uint32_t)*(num_active_cells + 1);
+    *extra_data_size = sizeof(uint32_t)*(num_active_cells);
 
     uint32_t *mapping = (uint32_t*)malloc(*extra_data_size);
 
@@ -26,8 +26,6 @@ SET_EXTRA_DATA (set_mixed_model_if_x_less_than)
     for (i = 0; i < num_active_cells; i++)
     {
         real center_x = ac[i]->center.x;
-//        real center_y = ac[i]->center.y;
-//        real center_z = ac[i]->center.z;
 
         inside = (center_x <= x_limit);
 

--- a/src/gui/color_maps.h
+++ b/src/gui/color_maps.h
@@ -7,7 +7,7 @@
 
 #define NUM_SCALES 7
 #define NUM_COLORS 257
-static double color_scales[NUM_SCALES][NUM_COLORS][3] = {
+static real_cpu color_scales[NUM_SCALES][NUM_COLORS][3] = {
         {
             //RAINBOW
             {0.2298057,0.298717966,0.753683153},

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -30,10 +30,10 @@ static int current_window_height = 0;
 static int current_window_width = 0;
 
 int info_box_lines;
-const int end_info_box_lines = 10;
-const int mesh_info_box_lines = 9;
 
-void gui_end_simulation(struct gui_config *gui_config, long res_time, long ode_total_time, long cg_total_time, long total_mat_time, long total_ref_time, long total_deref_time, long total_write_time, long total_config_time, long total_cg_it) {
+
+void gui_end_simulation(struct gui_config *gui_config, long res_time, long ode_total_time, long cg_total_time, long total_mat_time, 
+					    long total_ref_time, long total_deref_time, long total_write_time, long total_config_time, long total_cg_it) {
     gui_config->solver_time = res_time;
     gui_config->ode_total_time = ode_total_time;
     gui_config->cg_total_time = cg_total_time;
@@ -133,44 +133,37 @@ static inline float normalize(float r_min, float r_max, float t_min, float t_max
 
 static inline Color get_color(real_cpu value, int alpha, int current_scale) {
 
-    int idx1;                  // |-- Our desired color will be between these two indexes in "color".
-    int idx2;                  // |
-    real_cpu fractBetween = 0; // Fraction between "idx1" and "idx2" where our value is.
+    int idx1;                  
+    int idx2;                  
+    real_cpu fractBetween = 0; 
 
     if(value <= 0) {
         idx1 = idx2 = 0;
-    } // accounts for an input <=0
-    else if(value >= 1) {
+    } else if(value >= 1) {
         idx1 = idx2 = NUM_COLORS - 1;
-    } // accounts for an input >=0
-    else {
-        value = value * (NUM_COLORS - 1);      // Will multiply value by NUM_COLORS.
+    } else {
+        value = value * (NUM_COLORS - 1);
         idx1 = (int)floor(value);              // Our desired color will be after this index.
         idx2 = idx1 + 1;                       // ... and before this index (inclusive).
-        fractBetween = value - (real_cpu)idx1; // Distance between the two indexes (0-1).
+        fractBetween = value - (real_cpu)idx1;
     }
 
-    unsigned char red;
-    unsigned char green;
-    unsigned char blue;
+	real_cpu color_idx1_0 = color_scales[current_scale][idx1][0];
+	real_cpu color_idx1_1 = color_scales[current_scale][idx1][1];
+	real_cpu color_idx1_2 = color_scales[current_scale][idx1][2];
 
-    red =
-        (unsigned char)(((color_scales[current_scale][idx2][0] - color_scales[current_scale][idx1][0]) * fractBetween + color_scales[current_scale][idx1][0]) *
-                        255);
-    green =
-        (unsigned char)(((color_scales[current_scale][idx2][1] - color_scales[current_scale][idx1][1]) * fractBetween + color_scales[current_scale][idx1][1]) *
-                        255);
-    blue =
-        (unsigned char)(((color_scales[current_scale][idx2][2] - color_scales[current_scale][idx1][2]) * fractBetween + color_scales[current_scale][idx1][2]) *
-                        255);
+	real_cpu color_idx2_0 = color_scales[current_scale][idx2][0];
+	real_cpu color_idx2_1 = color_scales[current_scale][idx2][1];
+	real_cpu color_idx2_2 = color_scales[current_scale][idx2][2];
 
     Color result;
-    result.r = red;
-    result.g = green;
-    result.b = blue;
-    result.a = alpha;
 
-    return result;
+	result.r = (unsigned char)(((color_idx2_0 - color_idx1_0) * fractBetween + color_idx1_0) * 255);
+    result.g = (unsigned char)(((color_idx2_1 - color_idx1_1) * fractBetween + color_idx1_1) * 255);
+    result.b = (unsigned char)(((color_idx2_2 - color_idx1_2) * fractBetween + color_idx1_2) * 255);
+	result.a = alpha;
+
+	return result;
 }
 
 static Vector3 find_mesh_center(struct grid *grid_to_draw, struct mesh_info *mesh_info) {
@@ -1443,7 +1436,7 @@ static void handle_input(struct gui_config * gui_config, struct mesh_info *mesh_
     }
 }
 
-static int configure_info_boxes_sizes(struct gui_state *gui_state) {
+static int configure_info_boxes_sizes(struct gui_state *gui_state, int mesh_info_box_lines, int end_info_box_lines) {
     Vector2 txt_w_h;
     int text_offset;
     int box_w = 0;
@@ -1508,6 +1501,9 @@ void draw_coordinates(struct gui_state *gui_state) {
 }
 
 void init_and_open_gui_window(struct gui_config *gui_config) {
+
+	const int end_info_box_lines = 10;
+	const int mesh_info_box_lines = 9;
 
     omp_set_lock(&gui_config->sleep_lock);
 
@@ -1583,7 +1579,7 @@ void init_and_open_gui_window(struct gui_config *gui_config) {
 
     bool end_info_box_strings_configured = false;
 
-    int text_offset = configure_info_boxes_sizes(gui_state);
+    int text_offset = configure_info_boxes_sizes(gui_state, mesh_info_box_lines, end_info_box_lines);
 
     while(!WindowShouldClose()) {
 

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -26,14 +26,10 @@
 #include "../3dparty/raylib/src/rlgl.h"
 /////////
 
-static int current_window_height = 0;
-static int current_window_width = 0;
-
-int info_box_lines;
-
 
 void gui_end_simulation(struct gui_config *gui_config, long res_time, long ode_total_time, long cg_total_time, long total_mat_time, 
 					    long total_ref_time, long total_deref_time, long total_write_time, long total_config_time, long total_cg_it) {
+
     gui_config->solver_time = res_time;
     gui_config->ode_total_time = ode_total_time;
     gui_config->cg_total_time = cg_total_time;
@@ -46,7 +42,7 @@ void gui_end_simulation(struct gui_config *gui_config, long res_time, long ode_t
     gui_config->simulating = false;
 }
 
-void set_camera_params(Camera3D *camera) {
+static void set_camera_params(Camera3D *camera) {
     camera->position = (Vector3){0.1f, 0.1f, 20.f}; // Camera position
     camera->target = (Vector3){0.f, 0.f, 0.f};
     camera->up = (Vector3){0.0f, 1.0f, 0.0f}; // Camera up vector (rotation towards target)
@@ -57,7 +53,12 @@ void set_camera_params(Camera3D *camera) {
 
 static struct gui_state *new_gui_state_with_font_sizes(int font_size_small, int font_size_big) {
 
-    struct gui_state *gui_state = (struct gui_state *)calloc(1, sizeof(struct gui_state));
+    struct gui_state *gui_state = CALLOC_ONE_TYPE(struct gui_state);
+
+	int current_monitor = 0;
+    current_monitor = GetCurrentMonitor();
+    gui_state->current_window_width = GetMonitorWidth(current_monitor);
+    gui_state->current_window_height = GetMonitorHeight(current_monitor);
 
     set_camera_params(&(gui_state->camera));
 
@@ -79,7 +80,7 @@ static struct gui_state *new_gui_state_with_font_sizes(int font_size_small, int 
     gui_state->ray.position = (Vector3){FLT_MAX, FLT_MAX, FLT_MAX};
     gui_state->ray.direction = (Vector3){FLT_MAX, FLT_MAX, FLT_MAX};
     gui_state->current_selected_volume.position_draw = (Vector3){FLT_MAX, FLT_MAX, FLT_MAX};
-    gui_state->current_mouse_over_volume.position_draw = (Vector3){FLT_MAX, FLT_MAX, FLT_MAX};
+    gui_state->current_mouse_over_volume.position_draw = (Vector3){-1, -1, -1};
     gui_state->mouse_pos = (Vector2){0, 0};
     gui_state->current_scale = 0;
     gui_state->voxel_alpha = 255;
@@ -105,9 +106,9 @@ static struct gui_state *new_gui_state_with_font_sizes(int font_size_small, int 
     gui_state->ap_graph_config->graph.width = 900.0f;
 
     gui_state->ap_graph_config->graph.x = 100;
-    gui_state->ap_graph_config->graph.y = (float)current_window_height - gui_state->ap_graph_config->graph.height - 70;
-    gui_state->scale_bounds.x = (float)current_window_width - 30.0f;
-    gui_state->scale_bounds.y = (float)current_window_height / 1.5f;
+    gui_state->ap_graph_config->graph.y = (float)gui_state->current_window_height - gui_state->ap_graph_config->graph.height - 70;
+    gui_state->scale_bounds.x = (float)gui_state->current_window_width - 30.0f;
+    gui_state->scale_bounds.y = (float)gui_state->current_window_height / 1.5f;
 
     gui_state->scale_bounds.width = 20;
     gui_state->scale_bounds.height = 0;
@@ -121,17 +122,13 @@ static struct gui_state *new_gui_state_with_font_sizes(int font_size_small, int 
     return gui_state;
 }
 
-struct mesh_info *new_mesh_info() {
+static struct mesh_info *new_mesh_info() {
     struct mesh_info *mesh_info = (struct mesh_info *)malloc(sizeof(struct mesh_info));
     mesh_info->center_calculated = false;
     return mesh_info;
 }
 
-static inline float normalize(float r_min, float r_max, float t_min, float t_max, float m) {
-    return ((m - r_min) / (r_max - r_min)) * (t_max - t_min) + t_min;
-}
-
-static inline Color get_color(real_cpu value, int alpha, int current_scale) {
+static Color get_color(real_cpu value, int alpha, int current_scale) {
 
     int idx1;                  
     int idx2;                  
@@ -617,9 +614,9 @@ static void draw_ap_graph(struct gui_state *gui_state, struct gui_config *gui_co
     for(uint t = 0; t <= num_ticks; t++) {
 
         p1.x = (float)gui_state->ap_graph_config->graph.x + 5.0f;
-        p1.y = normalize(gui_config->min_v, gui_config->max_v, gui_state->ap_graph_config->min_y, gui_state->ap_graph_config->max_y, v);
+        p1.y = NORMALIZE(gui_config->min_v, gui_config->max_v, gui_state->ap_graph_config->min_y, gui_state->ap_graph_config->max_y, v);
 
-        sprintf(tmp, "%.2lf", normalize(gui_state->ap_graph_config->min_y, gui_state->ap_graph_config->max_y, gui_config->min_v, gui_config->max_v, p1.y));
+        sprintf(tmp, "%.2lf", NORMALIZE(gui_state->ap_graph_config->min_y, gui_state->ap_graph_config->max_y, gui_config->min_v, gui_config->max_v, p1.y));
         text_width = MeasureTextEx(font, tmp, (float)gui_state->font_size_small, spacing_small);
 
         DrawTextEx(font, tmp, (Vector2){p1.x + (max_w.x - text_width.x / 2) + 20, p1.y - text_width.y / 2.0f}, (float)gui_state->font_size_small, spacing_small,
@@ -654,14 +651,14 @@ static void draw_ap_graph(struct gui_state *gui_state, struct gui_config *gui_co
     // Draw horizontal ticks (t)
     for(uint t = 0; t <= num_ticks; t++) {
 
-        p1.x = normalize(0.0f, gui_config->final_time, gui_state->ap_graph_config->min_x, gui_state->ap_graph_config->max_x, time);
+        p1.x = NORMALIZE(0.0f, gui_config->final_time, gui_state->ap_graph_config->min_x, gui_state->ap_graph_config->max_x, time);
         p1.y = gui_state->ap_graph_config->min_y - 5;
 
         p2.x = p1.x;
         p2.y = gui_state->ap_graph_config->min_y + 5;
 
         if(!(t % 2)) {
-            sprintf(tmp, "%.2lf", normalize(gui_state->ap_graph_config->min_x, gui_state->ap_graph_config->max_x, 0.0f, gui_config->final_time, p1.x));
+            sprintf(tmp, "%.2lf", NORMALIZE(gui_state->ap_graph_config->min_x, gui_state->ap_graph_config->max_x, 0.0f, gui_config->final_time, p1.x));
             text_width = MeasureTextEx(font, tmp, (float)gui_state->font_size_small, spacing_small);
             DrawTextEx(font, tmp, (Vector2){p1.x - text_width.x / 2.0f, p1.y + 10}, (float)gui_state->font_size_small, spacing_small, RED);
         }
@@ -725,11 +722,11 @@ static void draw_ap_graph(struct gui_state *gui_state, struct gui_config *gui_co
                 if(aps[i].t <= gui_config->time) {
                     if(i + step < c) {
 
-                        p1.x = normalize(0.0f, gui_config->final_time, gui_state->ap_graph_config->min_x, gui_state->ap_graph_config->max_x, aps[i].t);
-                        p1.y = normalize(gui_config->min_v, gui_config->max_v, gui_state->ap_graph_config->min_y, gui_state->ap_graph_config->max_y, aps[i].v);
+                        p1.x = NORMALIZE(0.0f, gui_config->final_time, gui_state->ap_graph_config->min_x, gui_state->ap_graph_config->max_x, aps[i].t);
+                        p1.y = NORMALIZE(gui_config->min_v, gui_config->max_v, gui_state->ap_graph_config->min_y, gui_state->ap_graph_config->max_y, aps[i].v);
 
-                        p2.x = normalize(0.0f, gui_config->final_time, gui_state->ap_graph_config->min_x, gui_state->ap_graph_config->max_x, aps[i + step].t);
-                        p2.y = normalize(gui_config->min_v, gui_config->max_v, gui_state->ap_graph_config->min_y, gui_state->ap_graph_config->max_y,
+                        p2.x = NORMALIZE(0.0f, gui_config->final_time, gui_state->ap_graph_config->min_x, gui_state->ap_graph_config->max_x, aps[i + step].t);
+                        p2.y = NORMALIZE(gui_config->min_v, gui_config->max_v, gui_state->ap_graph_config->min_y, gui_state->ap_graph_config->max_y,
                                          aps[i + step].v);
 
                         // TODO: create an option for this???
@@ -763,9 +760,9 @@ static void draw_ap_graph(struct gui_state *gui_state, struct gui_config *gui_co
         DrawCircleV(gui_state->ap_graph_config->selected_point_for_apd2, 4, RED);
         DrawLineV(gui_state->ap_graph_config->selected_point_for_apd1, gui_state->ap_graph_config->selected_point_for_apd2, RED);
 
-        float t1 = normalize(gui_state->ap_graph_config->min_x, gui_state->ap_graph_config->max_x, 0.0f, gui_config->final_time,
+        float t1 = NORMALIZE(gui_state->ap_graph_config->min_x, gui_state->ap_graph_config->max_x, 0.0f, gui_config->final_time,
                              gui_state->ap_graph_config->selected_point_for_apd1.x);
-        float t2 = normalize(gui_state->ap_graph_config->min_x, gui_state->ap_graph_config->max_x, 0.0f, gui_config->final_time,
+        float t2 = NORMALIZE(gui_state->ap_graph_config->min_x, gui_state->ap_graph_config->max_x, 0.0f, gui_config->final_time,
                              gui_state->ap_graph_config->selected_point_for_apd2.x);
 
         char *tmp_point = "dt = %lf";
@@ -803,7 +800,7 @@ static inline void drag_scale(Vector2 new_pos, Rectangle *box) {
     move_rect((Vector2){new_x, new_y}, box);
 }
 
-static void check_window_bounds(Rectangle *box) {
+static void check_window_bounds(Rectangle *box, int current_window_width, int current_window_height) {
     if(box->x + box->width > current_window_width)
         move_rect((Vector2){current_window_width - box->width - 10, box->y}, box);
 
@@ -814,7 +811,7 @@ static void check_window_bounds(Rectangle *box) {
 static void draw_scale(real_cpu min_v, real_cpu max_v, struct gui_state *gui_state, bool int_scale) {
 
     static const int scale_width = 20;
-    check_window_bounds(&(gui_state->scale_bounds));
+    check_window_bounds(&(gui_state->scale_bounds), gui_state->current_window_width, gui_state->current_window_width);
 
     static bool calc_bounds = true;
 
@@ -891,9 +888,9 @@ static void draw_scale(real_cpu min_v, real_cpu max_v, struct gui_state *gui_sta
     }
 }
 
-static void draw_box(Rectangle *box, int text_offset, const char **lines, int num_lines, int font_size_for_line, Font font) {
+static void draw_box(Rectangle *box, int text_offset, const char **lines, int num_lines, int font_size_for_line, Font font, int current_window_width, int current_window_height) {
 
-    check_window_bounds(box);
+    check_window_bounds(box, current_window_width, current_window_height);
 
     int text_x = (int)box->x + 20;
     int text_y = (int)box->y + 10;
@@ -1097,7 +1094,7 @@ static void reset(struct gui_config *gui_config, struct mesh_info *mesh_info, st
     gui_state->ray.direction = (Vector3){FLT_MAX, FLT_MAX, FLT_MAX};
     omp_unset_lock(&gui_config->sleep_lock);
     gui_state->current_selected_volume.position_draw = (Vector3){FLT_MAX, FLT_MAX, FLT_MAX};
-    gui_state->current_mouse_over_volume.position_draw = (Vector3){FLT_MAX, FLT_MAX, FLT_MAX};
+    gui_state->current_mouse_over_volume.position_draw = (Vector3){-1, -1, -1};
     gui_state->ap_graph_config->selected_point_for_apd1 = (Vector2){FLT_MAX, FLT_MAX};
     gui_state->ap_graph_config->selected_point_for_apd2 = (Vector2){FLT_MAX, FLT_MAX};
 }
@@ -1424,8 +1421,8 @@ static void handle_input(struct gui_config * gui_config, struct mesh_info *mesh_
     }
 
     if(hmlen(gui_state->ap_graph_config->selected_aps) && gui_state->show_ap) {
-        float t = normalize(gui_state->ap_graph_config->min_x, gui_state->ap_graph_config->max_x, 0.0f, gui_config->final_time, gui_state->mouse_pos.x);
-        float v = normalize(gui_state->ap_graph_config->min_y, gui_state->ap_graph_config->max_y, gui_config->min_v, gui_config->max_v, gui_state->mouse_pos.y);
+        float t = NORMALIZE(gui_state->ap_graph_config->min_x, gui_state->ap_graph_config->max_x, 0.0f, gui_config->final_time, gui_state->mouse_pos.x);
+        float v = NORMALIZE(gui_state->ap_graph_config->min_y, gui_state->ap_graph_config->max_y, gui_config->min_v, gui_config->max_v, gui_state->mouse_pos.y);
         if(CheckCollisionPointRec(gui_state->mouse_pos, gui_state->ap_graph_config->graph)) {
             gui_state->ap_graph_config->selected_ap_point.x = t;
             gui_state->ap_graph_config->selected_ap_point.y = v;
@@ -1436,7 +1433,7 @@ static void handle_input(struct gui_config * gui_config, struct mesh_info *mesh_
     }
 }
 
-static int configure_info_boxes_sizes(struct gui_state *gui_state, int mesh_info_box_lines, int end_info_box_lines) {
+static int configure_info_boxes_sizes(struct gui_state *gui_state, int info_box_lines, int mesh_info_box_lines, int end_info_box_lines) {
     Vector2 txt_w_h;
     int text_offset;
     int box_w = 0;
@@ -1451,7 +1448,7 @@ static int configure_info_boxes_sizes(struct gui_state *gui_state, int mesh_info
     gui_state->mesh_info_box.width = (float)box_w;
     gui_state->mesh_info_box.height = (float)(text_offset * mesh_info_box_lines) + 10;
 
-    gui_state->mesh_info_box.x = (float)(current_window_width - box_w - 10);
+    gui_state->mesh_info_box.x = (float)(gui_state->current_window_width - box_w - 10);
     gui_state->mesh_info_box.y = 10.0f;
 
     gui_state->end_info_box.width = (float)box_w;
@@ -1519,15 +1516,12 @@ void init_and_open_gui_window(struct gui_config *gui_config) {
         window_title = strdup("Opening mesh...");
     }
 
-    int current_monitor = 0;
 
-    InitWindow(current_window_width, current_window_height, window_title);
+    InitWindow(0, 0, window_title);
+    
+    struct gui_state *gui_state = new_gui_state_with_font_sizes(14, 18);
 
-    current_monitor = GetCurrentMonitor();
-    current_window_width = GetMonitorWidth(current_monitor);
-    current_window_height = GetMonitorHeight(current_monitor);
-
-    SetWindowSize(current_window_width, current_window_height);
+    SetWindowSize(gui_state->current_window_width, gui_state->current_window_height);
 
     free(window_title);
 
@@ -1567,7 +1561,7 @@ void init_and_open_gui_window(struct gui_config *gui_config) {
                                       " - Double click on a volume to show the AP",
                                       " - Space to start or pause simulation"};
 
-    info_box_lines = SIZEOF(info_box_strings);
+    int info_box_lines = SIZEOF(info_box_strings);
 
     end_info_box_strings = (char **)malloc(sizeof(char *) * end_info_box_lines);
     mesh_info_box_strings = (char **)malloc(sizeof(char *) * mesh_info_box_lines);
@@ -1575,11 +1569,10 @@ void init_and_open_gui_window(struct gui_config *gui_config) {
     Vector2 error_message_witdh;
 
     struct mesh_info *mesh_info = new_mesh_info();
-    struct gui_state *gui_state = new_gui_state_with_font_sizes(14, 18);
 
     bool end_info_box_strings_configured = false;
 
-    int text_offset = configure_info_boxes_sizes(gui_state, mesh_info_box_lines, end_info_box_lines);
+    int text_offset = configure_info_boxes_sizes(gui_state, info_box_lines, mesh_info_box_lines, end_info_box_lines);
 
     while(!WindowShouldClose()) {
 
@@ -1590,8 +1583,8 @@ void init_and_open_gui_window(struct gui_config *gui_config) {
         BeginDrawing();
 
         if(IsWindowResized()) {
-            current_window_height = GetScreenHeight();
-            current_window_width = GetScreenWidth();
+            gui_state->current_window_height = GetScreenHeight();
+            gui_state->current_window_width = GetScreenWidth();
         }
 
         gui_state->handle_keyboard_input = !gui_state->show_selection_box;
@@ -1648,7 +1641,7 @@ void init_and_open_gui_window(struct gui_config *gui_config) {
 
                 if(configured) {
                     draw_box(&gui_state->mesh_info_box, text_offset, (const char **)mesh_info_box_strings, mesh_info_box_lines, (int)gui_state->font_size_small,
-                             gui_state->font);
+                             gui_state->font, gui_state->current_window_width, gui_state->current_window_height);
 
                     for(int i = 0; i < mesh_info_box_lines; i++) {
                         free(mesh_info_box_strings[i]);
@@ -1667,7 +1660,8 @@ void init_and_open_gui_window(struct gui_config *gui_config) {
             }
 
             if(gui_state->show_help_box) {
-                draw_box(&gui_state->help_box, text_offset, info_box_strings, info_box_lines, (int)gui_state->font_size_small, gui_state->font);
+                draw_box(&gui_state->help_box, text_offset, info_box_strings, info_box_lines, (int)gui_state->font_size_small, gui_state->font,
+						 gui_state->current_window_width, gui_state->current_window_height);
             }
 
             if(!gui_config->simulating) {
@@ -1678,7 +1672,7 @@ void init_and_open_gui_window(struct gui_config *gui_config) {
                             end_info_box_strings_configured = true;
                         }
                         draw_box(&gui_state->end_info_box, text_offset, (const char **)end_info_box_strings, end_info_box_lines,
-                                 (int)gui_state->font_size_small, gui_state->font);
+                                 (int)gui_state->font_size_small, gui_state->font, gui_state->current_window_width, gui_state->current_window_height);
                     }
                 }
             }
@@ -1718,11 +1712,16 @@ void init_and_open_gui_window(struct gui_config *gui_config) {
         // Draw FPS
         int fps = GetFPS();
         DrawText(TextFormat("%2i FPS", fps), GetScreenWidth() - 100, GetScreenHeight() - 20, 20, BLACK);
-        DrawText(TextFormat("Mouse is on Volume: %lf, %lf, %lf with grid position %i", gui_state->current_mouse_over_volume.position_draw.x,
+	
+		if(gui_state->current_mouse_over_volume.position_draw.x != -1) {
+		
+			DrawText(TextFormat("Mouse is on Volume: %lf, %lf, %lf with grid position %i", gui_state->current_mouse_over_volume.position_draw.x,
                             gui_state->current_mouse_over_volume.position_draw.y, gui_state->current_mouse_over_volume.position_draw.z,
                             gui_state->current_mouse_over_volume.matrix_position + 1),
                  GetScreenWidth() - MeasureText("Mouse is on Volume: 10000, 10000, 10000 with grid position 10000", 20) * 1.4, GetScreenHeight() - 50, 20,
                  BLACK);
+		}
+
         EndDrawing();
     }
 

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -23,6 +23,8 @@
 #define WIDER_TEXT "------------------------------------------------------"
 #define DOUBLE_CLICK_DELAY 0.8 //seconds
 
+#define NORMALIZE(r_min, r_max, t_min, t_max, m) (((m - r_min) / (r_max - r_min)) * (t_max - t_min) + t_min)
+
 struct action_potential {
     real_cpu v;
     real_cpu t;
@@ -37,7 +39,6 @@ struct vector3_voidp_hash_entry {
     Vector3 key;
     void *value;
 };
-
 
 struct ap_graph_config {
 
@@ -117,6 +118,9 @@ struct gui_config {
 
 struct gui_state {
 
+	int current_window_width;
+	int current_window_height;
+
     bool handle_keyboard_input;
     bool one_selected;
     bool show_ap;
@@ -193,6 +197,9 @@ struct mesh_info {
 };
 
 void init_and_open_gui_window(struct gui_config *gui_config);
-void gui_end_simulation(struct gui_config *gui_config, long res_time, long ode_total_time, long cg_total_time, long total_mat_time, long total_ref_time, long total_deref_time, long total_write_time, long total_config_time, long total_cg_it);
+
+void gui_end_simulation(struct gui_config *gui_config, long res_time, long ode_total_time, long cg_total_time, 
+						long total_mat_time, long total_ref_time, long total_deref_time, long total_write_time, 
+						long total_config_time, long total_cg_it);
 
 #endif //MONOALG3D_DRAW_H

--- a/src/libraries_common/common_data_structures.h
+++ b/src/libraries_common/common_data_structures.h
@@ -20,6 +20,12 @@ struct fibrotic_mesh_info {
     char scar_type;
 };
 
+struct scv_mesh_info {
+    bool fibrotic;
+    bool border_zone;
+	int tissue_type;
+};
+
 #define FIBROTIC_INFO(grid_cell) (struct fibrotic_mesh_info *)grid_cell->mesh_extra_info
 #define FIBROTIC(grid_cell) (FIBROTIC_INFO(grid_cell))->fibrotic
 #define BORDER_ZONE(grid_cell) (FIBROTIC_INFO(grid_cell))->border_zone
@@ -37,6 +43,15 @@ struct fibrotic_mesh_info {
         TISSUE_TYPE ((grid_cell)) = '0';                                                                               \
 } while (0)
 
+#define INITIALIZE_SCV_INFO(grid_cell)                                                                                 \
+    do {                                                                                                               \
+        size_t __size__ = sizeof (struct scv_mesh_info);                                                               \
+        (grid_cell)->mesh_extra_info = malloc (__size__);                                                              \
+        (grid_cell)->mesh_extra_info_size = __size__;                                                                  \
+        FIBROTIC ((grid_cell)) = false;                                                                                \
+        BORDER_ZONE (grid_cell) = false;                                                                               \
+        TISSUE_TYPE ((grid_cell)) = 0;                                                                                 \
+} while (0)
 
 struct conjugate_gradient_info {
     real_cpu r;  /* Element of the int_vector r = b - Ax associated to this cell. */

--- a/src/main_converter.c
+++ b/src/main_converter.c
@@ -12,7 +12,7 @@
 #include <ctype.h>
 #include <sys/stat.h>
 
-void convert_file(const char *input, const char *output, const char *file_name) {
+static void convert_file(const char *input, const char *output, const char *file_name, uint32_t value_index) {
 
     sds full_input_path;
 
@@ -33,9 +33,9 @@ void convert_file(const char *input, const char *output, const char *file_name) 
 
     get_path_information(full_input_path, &file_info);
 
-    if(FILE_HAS_EXTENSION(file_info.file_extension, "txt")) {
+    if(FILE_HAS_EXTENSION(file_info.file_extension, "txt") || FILE_HAS_EXTENSION(file_info.file_extension, "alg")) {
 
-        vtk_grid = new_vtk_unstructured_grid_from_file(full_input_path);
+        vtk_grid = new_vtk_unstructured_grid_from_file_with_index(full_input_path, value_index);
 
         if(!vtk_grid) {
             fprintf(stderr, "%s is not a valid simulation file. Skipping!!\n", full_input_path);
@@ -59,7 +59,6 @@ void convert_file(const char *input, const char *output, const char *file_name) 
 
             free_path_information(&file_info);
             sdsfree(full_input_path);
-
         }
 
     }
@@ -95,20 +94,32 @@ void convert_file(const char *input, const char *output, const char *file_name) 
 
 int main(int argc, char **argv) {
 
-    struct conversion_options *options = new_conversion_options();
+	struct conversion_options *options = new_conversion_options();
 
-    parse_conversion_options(argc, argv, options);
+	parse_conversion_options(argc, argv, options);
 
-    char *input = options->input;
-    char *output = options->output;
+	if(options->value_index < 0) {
+		fprintf(stderr, "Invalid index for the value to be saved (%d)! The value parameter should be >= 0\n", options->value_index);
+		return EXIT_FAILURE;
+	}
 
-    struct path_information input_info;
+	uint32_t value_index = options->value_index;
 
-    get_path_information(input, &input_info);
+	char *input = options->input;
+	char *output = options->output;
 
-    if(!output) {
+	struct path_information input_info;
 
-        output = sdsempty();
+	get_path_information(input, &input_info);
+
+	if(!input_info.exists) {
+		fprintf(stderr, "Invalid directory or file (%s)! The input parameter should be and valid simulation file, alg file or a directory containing simulations!\n", input);
+		return EXIT_FAILURE;
+	}
+
+	if(!output) {
+
+		output = sdsempty();
 
 		if(input_info.is_dir) {
 			if(ENDS_WITH_SLASH(input)) {
@@ -117,42 +128,37 @@ int main(int argc, char **argv) {
 				output = sdscatfmt(output, "%s/converted_files", input);
 			}
 		}
-		else if(input_info.exists && input_info.is_file) {
+		else {
 			if(ENDS_WITH_SLASH(input_info.dir_name)) {
 				output = sdscatfmt(output, "%sconverted_files", input_info.dir_name);
 			} else {
 				output = sdscatfmt(output, "%s/converted_files", input_info.dir_name);
 			}
 		}
-    }
+	}
 
-   if(!input_info.exists) {
-        fprintf(stderr, "Invalid directory or txt file (%s)! The input parameter should be and valid txt simulation file or a directory containing simulations!\n", input);
-    }
-    else if(input_info.is_dir) {
+	if(input_info.is_dir) {
 
-        create_dir(output);
-        string_array files_list = list_files_from_dir(input, NULL, NULL, true);
+		create_dir(output);
+		string_array files_list = list_files_from_dir(input, NULL, NULL, true);
 
-        int num_files = arrlen(files_list);
+		int num_files = arrlen(files_list);
 
-        if(num_files == 0) {
-            fprintf(stderr, "Directory %s is empty\n", input);
-            exit(EXIT_FAILURE);
-        }
-        else {
-            for(int i = 0; i < num_files; i++) {
-                convert_file(input, output, files_list[i]);
-            }
-        }
-    }
-    else {
-        create_dir(output);
-        convert_file(input, output, NULL);
+		if(num_files == 0) {
+			fprintf(stderr, "Directory %s is empty\n", input);
+			exit(EXIT_FAILURE);
+		}
+		else {
+			for(int i = 0; i < num_files; i++) {
+				convert_file(input, output, files_list[i], value_index);
+			}
+		}
+	}
+	else {
+		create_dir(output);
+		convert_file(input, output, NULL, value_index);
+	}
 
-    }
-
-
-    return EXIT_SUCCESS;
+	return EXIT_SUCCESS;
 }
 

--- a/src/main_simulator.c
+++ b/src/main_simulator.c
@@ -132,6 +132,7 @@ static void init_gui_config_for_simulation(struct user_options *options, struct 
 int main(int argc, char **argv) {
 
     struct user_options *options = NULL;
+
     struct grid *the_grid;
     struct monodomain_solver *monodomain_solver = NULL;
     struct ode_solver *ode_solver = NULL;
@@ -161,45 +162,45 @@ int main(int argc, char **argv) {
     omp_set_num_threads(np);
 #endif
 
-    //If COMPILE_GUI is not set this is always false. See above.
+    // If COMPILE_GUI is not set this is always false. See above.
     if(options->show_gui) {
 
-       #ifdef COMPILE_GUI //If this is defined so OMP is also defined
+       	#ifdef COMPILE_GUI //If this is defined so OMP is also defined
 
-        struct gui_config *gui_config = MALLOC_ONE_TYPE(struct gui_config);
+			struct gui_config *gui_config = MALLOC_ONE_TYPE(struct gui_config);
 
-        omp_set_nested(true);
+			omp_set_nested(true);
 
-        init_gui_config_for_simulation(options, gui_config, false);
+			init_gui_config_for_simulation(options, gui_config, false);
 
-        OMP(parallel sections num_threads(2))
-        {
-            OMP(section)
-            {
-                init_and_open_gui_window(gui_config);
-            }
+			OMP(parallel sections num_threads(2))
+			{
+				OMP(section)
+				{
+					init_and_open_gui_window(gui_config);
+				}
 
-            OMP(section)
-            {
-                int result = solve_monodomain(monodomain_solver, ode_solver, the_grid, options, gui_config);
+				OMP(section)
+				{
+					int result = solve_monodomain(monodomain_solver, ode_solver, the_grid, options, gui_config);
 
-                while (result == RESTART_SIMULATION || result == SIMULATION_FINISHED) {
-                    if(result == RESTART_SIMULATION) {
-                        free_current_simulation_resources(options, monodomain_solver, ode_solver, the_grid);
-                        configure_simulation(argc, argv, &options, &monodomain_solver, &ode_solver, &the_grid);
-                        init_gui_config_for_simulation(options, gui_config, true);
-                        result = solve_monodomain(monodomain_solver, ode_solver, the_grid, options, gui_config);
-                    }
+					while (result == RESTART_SIMULATION || result == SIMULATION_FINISHED) {
+						if(result == RESTART_SIMULATION) {
+							free_current_simulation_resources(options, monodomain_solver, ode_solver, the_grid);
+							configure_simulation(argc, argv, &options, &monodomain_solver, &ode_solver, &the_grid);
+							init_gui_config_for_simulation(options, gui_config, true);
+							result = solve_monodomain(monodomain_solver, ode_solver, the_grid, options, gui_config);
+						}
 
-                    if(gui_config->restart) result = RESTART_SIMULATION;
+						if(gui_config->restart) result = RESTART_SIMULATION;
 
-                    if(gui_config->exit)  {
-                        free_current_simulation_resources(options, monodomain_solver, ode_solver, the_grid);
-                        break;
-                    }
-                }
-            }
-        }
+						if(gui_config->exit)  {
+							free_current_simulation_resources(options, monodomain_solver, ode_solver, the_grid);
+							break;
+						}
+					}
+				}
+			}
 
         #endif //COMPILE_GUI
     } else {

--- a/src/models_library/ten_tusscher/build.sh
+++ b/src/models_library/ten_tusscher/build.sh
@@ -36,3 +36,12 @@ COMMON_HEADERS="ten_tusscher_2004_epi.h"
 
 COMPILE_MODEL_LIB "ten_tusscher_2004_epi" "$MODEL_FILE_CPU" "$MODEL_FILE_GPU" "$COMMON_HEADERS"
 ############################################################################################
+
+############## TENTUSSCHER MIXED MYO EPI #####################################################
+MODEL_FILE_CPU="mixed_tentusscher_myo_epi_2004.c"
+MODEL_FILE_GPU="mixed_tentusscher_myo_epi_2004.cu"
+COMMON_HEADERS="mixed_tentusscher_myo_epi_2004.h"
+
+COMPILE_MODEL_LIB "mixed_tentusscher_myo_epi_2004" "$MODEL_FILE_CPU" "$MODEL_FILE_GPU" "$COMMON_HEADERS"
+############################################################################################
+

--- a/src/models_library/ten_tusscher/build.sh
+++ b/src/models_library/ten_tusscher/build.sh
@@ -45,3 +45,11 @@ COMMON_HEADERS="mixed_tentusscher_myo_epi_2004.h"
 COMPILE_MODEL_LIB "mixed_tentusscher_myo_epi_2004" "$MODEL_FILE_CPU" "$MODEL_FILE_GPU" "$COMMON_HEADERS"
 ############################################################################################
 
+############## TENTUSSCHER MIXED ENDO MID EPI #####################################################
+MODEL_FILE_CPU="ten_tusscher_2004_mixed_endo_mid_epi.c"
+MODEL_FILE_GPU="ten_tusscher_2004_mixed_endo_mid_epi.cu"
+COMMON_HEADERS="ten_tusscher_2004_mixed_endo_mid_epi.h"
+
+COMPILE_MODEL_LIB "ten_tusscher_2004_mixed_endo_mid_epi" "$MODEL_FILE_CPU" "$MODEL_FILE_GPU" "$COMMON_HEADERS"
+############################################################################################
+

--- a/src/models_library/ten_tusscher/mixed_tentusscher_myo_epi_2004.c
+++ b/src/models_library/ten_tusscher/mixed_tentusscher_myo_epi_2004.c
@@ -1,0 +1,897 @@
+#include <stdio.h>
+#include "mixed_tentusscher_myo_epi_2004.h"
+
+GET_CELL_MODEL_DATA(init_cell_model_data) 
+{
+
+    if(get_initial_v)
+        cell_model->initial_v = INITIAL_V;
+    if(get_neq)
+        cell_model->number_of_ode_equations = NEQ;
+}
+
+SET_ODE_INITIAL_CONDITIONS_CPU(set_model_initial_conditions_cpu) 
+{
+
+	log_to_stdout_and_file("Using mixed version of TenTusscher 2004 myocardium + epicardium CPU model\n");
+
+	// Get the mapping array
+	uint32_t *mapping = NULL;
+	if(solver->ode_extra_data) 
+	{
+		mapping = (uint32_t*)solver->ode_extra_data;
+	}
+	else 
+	{
+		log_to_stderr_and_file_and_exit("You need to specify a mask function when using a mixed model!\n");
+	}
+
+	uint32_t num_cells = solver->original_num_cells;
+
+	solver->sv = (real*)malloc(NEQ*num_cells*sizeof(real));
+
+	OMP(parallel for)
+	for(uint32_t i = 0; i < num_cells; i++) {
+
+		real *sv = &solver->sv[i * NEQ];
+
+		// Initial conditions for TenTusscher myocardium
+		if (mapping[i] == 0)
+		{
+			sv[0] =  INITIAL_V;     // V;       millivolt
+			sv[1] =  0.f;           //M
+			sv[2] =  0.75;          //H
+			sv[3] =  0.75f;         //J
+			sv[4] =  0.f;           //Xr1
+			sv[5] =  1.f;           //Xr2
+			sv[6] =  0.f;           //Xs
+			sv[7] =  1.f;           //S
+			sv[8] =  0.f;           //R
+			sv[9] =  0.f;           //D
+			sv[10] = 1.f;           //F
+			sv[11] = 1.f;           //FCa
+			sv[12] = 1.f;           //G
+			sv[13] = 0.0002;        //Cai
+			sv[14] = 0.2f;          //CaSR
+			sv[15] = 11.6f;         //Nai
+			sv[16] = 138.3f;        //Ki
+		}
+		// Initial conditions for TenTusscher epicardium
+		else
+		{
+			sv[0] =  INITIAL_V;     // V;       millivolt
+			sv[1] =  0.f;           //M
+			sv[2] =  0.75;          //H
+			sv[3] =  0.75f;         //J
+			sv[4] =  0.f;           //Xr1
+			sv[5] =  1.f;           //Xr2
+			sv[6] =  0.f;           //Xs
+			sv[7] =  1.f;           //S
+			sv[8] =  0.f;           //R
+			sv[9] =  0.f;           //D
+			sv[10] = 1.f;           //F
+			sv[11] = 1.f;           //FCa
+			sv[12] = 1.f;           //G
+			sv[13] = 0.0002;        //Cai
+			sv[14] = 0.2f;          //CaSR
+			sv[15] = 11.6f;         //Nai
+			sv[16] = 138.3f;        //Ki
+		}
+	}
+}
+
+SOLVE_MODEL_ODES(solve_model_odes_cpu) 
+{
+
+    // Get the mapping array
+    uint32_t *mapping = NULL;
+    if(ode_solver->ode_extra_data) 
+    {
+        mapping = (uint32_t*)ode_solver->ode_extra_data;
+    }
+    else 
+    {
+        log_to_stderr_and_file_and_exit("You need to specify a mask function when using a mixed model!\n");
+    }
+
+
+ 	size_t num_cells_to_solve = ode_solver->num_cells_to_solve;
+    uint32_t * cells_to_solve = ode_solver->cells_to_solve;
+    real *sv = ode_solver->sv;
+	uint32_t num_steps = ode_solver->num_steps;
+	real dt = ode_solver->min_dt;
+
+
+    uint32_t sv_id;
+
+	int i;
+
+    #pragma omp parallel for private(sv_id)
+    for (i = 0; i < num_cells_to_solve; i++) 
+    {
+
+        if(cells_to_solve)
+            sv_id = cells_to_solve[i];
+        else
+            sv_id = (uint32_t )i;
+
+        for (int j = 0; j < num_steps; ++j) 
+        {
+            if (mapping[i] == 0)
+                solve_model_ode_cpu_myo(dt, sv + (sv_id * NEQ), stim_currents[i]);
+            else
+                solve_model_ode_cpu_epi(dt, sv + (sv_id * NEQ), stim_currents[i]);
+        }
+    }
+}
+
+void solve_model_ode_cpu_myo (real dt, real *sv, real stim_current)  
+{
+
+    real rY[NEQ], rDY[NEQ];
+
+    for(int i = 0; i < NEQ; i++)
+        rY[i] = sv[i];
+
+    RHS_cpu_myo(rY, rDY, stim_current, dt);
+
+    for(int i = 0; i < NEQ; i++)
+        sv[i] = rDY[i];
+    
+}
+
+void RHS_cpu_myo(const real *sv, real *rDY_, real stim_current, real dt) 
+{
+
+    // State variables
+    real svolt = sv[0];
+    real sm    = sv[1];
+    real sh    = sv[2];
+    real sj    = sv[3];
+    real sxr1  = sv[4];
+    real sxr2  = sv[5];
+    real sxs   = sv[6];
+    real ss    = sv[7];
+    real sr    = sv[8];
+    real sd    = sv[9];
+    real sf    = sv[10];
+    real sfca  = sv[11];
+    real sg    = sv[12];
+    real Cai   = sv[13];
+    real CaSR  = sv[14];
+    real Nai   = sv[15];
+    real Ki    = sv[16];
+
+    //External concentrations
+    real Ko=5.4;
+    real Cao=2.0;
+    real Nao=140.0;
+
+    //Intracellular volumes
+    real Vc=0.016404;
+    real Vsr=0.001094;
+
+    //Calcium dynamics
+    real Bufc=0.15f;
+    real Kbufc=0.001f;
+    real Bufsr=10.f;
+    real Kbufsr=0.3f;
+    real taufca=2.f;
+    real taug=2.f;
+    real Vmaxup=0.000425f;
+    real Kup=0.00025f;
+
+    //Constants
+    const real R = 8314.472f;
+    const real F = 96485.3415f;
+    const real T =310.0f;
+    real RTONF   =(R*T)/F;
+
+    //Cellular capacitance         
+    real CAPACITANCE=0.185;
+
+    //Parameters for currents
+    //Parameters for IKr
+    real Gkr=0.096;
+    //Parameters for Iks
+    real pKNa=0.03;
+
+// [!] Myocardium cell
+    real Gks=0.062;
+//Parameters for Ik1
+    real GK1=5.405;
+//Parameters for Ito
+// [!] Myocardium cell
+    real Gto=0.294;
+//Parameters for INa
+    real GNa=14.838;
+//Parameters for IbNa
+    real GbNa=0.00029;
+//Parameters for INaK
+    real KmK=1.0;
+    real KmNa=40.0;
+    real knak=1.362;
+//Parameters for ICaL
+    real GCaL=0.000175;
+//Parameters for IbCa
+    real GbCa=0.000592;
+//Parameters for INaCa
+    real knaca=1000;
+    real KmNai=87.5;
+    real KmCa=1.38;
+    real ksat=0.1;
+    real n=0.35;
+//Parameters for IpCa
+    real GpCa=0.825;
+    real KpCa=0.0005;
+//Parameters for IpK;
+    real GpK=0.0146;
+
+
+    real IKr;
+    real IKs;
+    real IK1;
+    real Ito;
+    real INa;
+    real IbNa;
+    real ICaL;
+    real IbCa;
+    real INaCa;
+    real IpCa;
+    real IpK;
+    real INaK;
+    real Irel;
+    real Ileak;
+
+
+    real dNai;
+    real dKi;
+    real dCai;
+    real dCaSR;
+
+    real A;
+//    real BufferFactorc;
+//    real BufferFactorsr;
+    real SERCA;
+    real Caisquare;
+    real CaSRsquare;
+    real CaCurrent;
+    real CaSRCurrent;
+
+
+    real fcaold;
+    real gold;
+    real Ek;
+    real Ena;
+    real Eks;
+    real Eca;
+    real CaCSQN;
+    real bjsr;
+    real cjsr;
+    real CaBuf;
+    real bc;
+    real cc;
+    real Ak1;
+    real Bk1;
+    real rec_iK1;
+    real rec_ipK;
+    real rec_iNaK;
+    real AM;
+    real BM;
+    real AH_1;
+    real BH_1;
+    real AH_2;
+    real BH_2;
+    real AJ_1;
+    real BJ_1;
+    real AJ_2;
+    real BJ_2;
+    real M_INF;
+    real H_INF;
+    real J_INF;
+    real TAU_M;
+    real TAU_H;
+    real TAU_J;
+    real axr1;
+    real bxr1;
+    real axr2;
+    real bxr2;
+    real Xr1_INF;
+    real Xr2_INF;
+    real TAU_Xr1;
+    real TAU_Xr2;
+    real Axs;
+    real Bxs;
+    real Xs_INF;
+    real TAU_Xs;
+    real R_INF;
+    real TAU_R;
+    real S_INF;
+    real TAU_S;
+    real Ad;
+    real Bd;
+    real Cd;
+    real TAU_D;
+    real D_INF;
+    real TAU_F;
+    real F_INF;
+    real FCa_INF;
+    real G_INF;
+
+    real inverseVcF2=1/(2*Vc*F);
+    real inverseVcF=1./(Vc*F);
+    real Kupsquare=Kup*Kup;
+//    real BufcKbufc=Bufc*Kbufc;
+//    real Kbufcsquare=Kbufc*Kbufc;
+//    real Kbufc2=2*Kbufc;
+//    real BufsrKbufsr=Bufsr*Kbufsr;
+//    const real Kbufsrsquare=Kbufsr*Kbufsr;
+//    const real Kbufsr2=2*Kbufsr;
+    const real exptaufca=exp(-dt/taufca);
+    const real exptaug=exp(-dt/taug);
+
+    real sItot;
+
+    //Needed to compute currents
+    Ek=RTONF*(log((Ko/Ki)));
+    Ena=RTONF*(log((Nao/Nai)));
+    Eks=RTONF*(log((Ko+pKNa*Nao)/(Ki+pKNa*Nai)));
+    Eca=0.5*RTONF*(log((Cao/Cai)));
+    Ak1=0.1/(1.+exp(0.06*(svolt-Ek-200)));
+    Bk1=(3.*exp(0.0002*(svolt-Ek+100))+
+         exp(0.1*(svolt-Ek-10)))/(1.+exp(-0.5*(svolt-Ek)));
+    rec_iK1=Ak1/(Ak1+Bk1);
+    rec_iNaK=(1./(1.+0.1245*exp(-0.1*svolt*F/(R*T))+0.0353*exp(-svolt*F/(R*T))));
+    rec_ipK=1./(1.+exp((25-svolt)/5.98));
+
+
+    //Compute currents
+    INa=GNa*sm*sm*sm*sh*sj*(svolt-Ena);
+    ICaL=GCaL*sd*sf*sfca*4*svolt*(F*F/(R*T))*
+         (exp(2*svolt*F/(R*T))*Cai-0.341*Cao)/(exp(2*svolt*F/(R*T))-1.);
+    Ito=Gto*sr*ss*(svolt-Ek);
+    IKr=Gkr*sqrt(Ko/5.4)*sxr1*sxr2*(svolt-Ek);
+    IKs=Gks*sxs*sxs*(svolt-Eks);
+    IK1=GK1*rec_iK1*(svolt-Ek);
+    INaCa=knaca*(1./(KmNai*KmNai*KmNai+Nao*Nao*Nao))*(1./(KmCa+Cao))*
+          (1./(1+ksat*exp((n-1)*svolt*F/(R*T))))*
+          (exp(n*svolt*F/(R*T))*Nai*Nai*Nai*Cao-
+           exp((n-1)*svolt*F/(R*T))*Nao*Nao*Nao*Cai*2.5);
+    INaK=knak*(Ko/(Ko+KmK))*(Nai/(Nai+KmNa))*rec_iNaK;
+    IpCa=GpCa*Cai/(KpCa+Cai);
+    IpK=GpK*rec_ipK*(svolt-Ek);
+    IbNa=GbNa*(svolt-Ena);
+    IbCa=GbCa*(svolt-Eca);
+
+
+    //Determine total current
+    (sItot) = IKr    +
+              IKs   +
+              IK1   +
+              Ito   +
+              INa   +
+              IbNa  +
+              ICaL  +
+              IbCa  +
+              INaK  +
+              INaCa +
+              IpCa  +
+              IpK   +
+              stim_current;
+
+
+    //update concentrations
+    Caisquare=Cai*Cai;
+    CaSRsquare=CaSR*CaSR;
+    CaCurrent=-(ICaL+IbCa+IpCa-2.0f*INaCa)*inverseVcF2*CAPACITANCE;
+    A=0.016464f*CaSRsquare/(0.0625f+CaSRsquare)+0.008232f;
+    Irel=A*sd*sg;
+    Ileak=0.00008f*(CaSR-Cai);
+    SERCA=Vmaxup/(1.f+(Kupsquare/Caisquare));
+    CaSRCurrent=SERCA-Irel-Ileak;
+    CaCSQN=Bufsr*CaSR/(CaSR+Kbufsr);
+    dCaSR=dt*(Vc/Vsr)*CaSRCurrent;
+    bjsr=Bufsr-CaCSQN-dCaSR-CaSR+Kbufsr;
+    cjsr=Kbufsr*(CaCSQN+dCaSR+CaSR);
+    CaSR=(sqrt(bjsr*bjsr+4.*cjsr)-bjsr)/2.;
+    CaBuf=Bufc*Cai/(Cai+Kbufc);
+    dCai=dt*(CaCurrent-CaSRCurrent);
+    bc=Bufc-CaBuf-dCai-Cai+Kbufc;
+    cc=Kbufc*(CaBuf+dCai+Cai);
+    Cai=(sqrt(bc*bc+4*cc)-bc)/2;
+
+
+
+    dNai=-(INa+IbNa+3*INaK+3*INaCa)*inverseVcF*CAPACITANCE;
+    Nai+=dt*dNai;
+
+    dKi=-(stim_current+IK1+Ito+IKr+IKs-2*INaK+IpK)*inverseVcF*CAPACITANCE;
+    Ki+=dt*dKi;
+
+    //compute steady state values and time constants
+    AM=1./(1.+exp((-60.-svolt)/5.));
+    BM=0.1/(1.+exp((svolt+35.)/5.))+0.10/(1.+exp((svolt-50.)/200.));
+    TAU_M=AM*BM;
+    M_INF=1./((1.+exp((-56.86-svolt)/9.03))*(1.+exp((-56.86-svolt)/9.03)));
+    if (svolt>=-40.)
+    {
+        AH_1=0.;
+        BH_1=(0.77/(0.13*(1.+exp(-(svolt+10.66)/11.1))));
+        TAU_H= 1.0/(AH_1+BH_1);
+    }
+    else
+    {
+        AH_2=(0.057*exp(-(svolt+80.)/6.8));
+        BH_2=(2.7*exp(0.079*svolt)+(3.1e5)*exp(0.3485*svolt));
+        TAU_H=1.0/(AH_2+BH_2);
+    }
+    H_INF=1./((1.+exp((svolt+71.55)/7.43))*(1.+exp((svolt+71.55)/7.43)));
+    if(svolt>=-40.)
+    {
+        AJ_1=0.;
+        BJ_1=(0.6*exp((0.057)*svolt)/(1.+exp(-0.1*(svolt+32.))));
+        TAU_J= 1.0/(AJ_1+BJ_1);
+    }
+    else
+    {
+        AJ_2=(((-2.5428e4)*exp(0.2444*svolt)-(6.948e-6)*
+                                             exp(-0.04391*svolt))*(svolt+37.78)/
+              (1.+exp(0.311*(svolt+79.23))));
+        BJ_2=(0.02424*exp(-0.01052*svolt)/(1.+exp(-0.1378*(svolt+40.14))));
+        TAU_J= 1.0/(AJ_2+BJ_2);
+    }
+    J_INF=H_INF;
+
+    Xr1_INF=1./(1.+exp((-26.-svolt)/7.));
+    axr1=450./(1.+exp((-45.-svolt)/10.));
+    bxr1=6./(1.+exp((svolt-(-30.))/11.5));
+    TAU_Xr1=axr1*bxr1;
+    Xr2_INF=1./(1.+exp((svolt-(-88.))/24.));
+    axr2=3./(1.+exp((-60.-svolt)/20.));
+    bxr2=1.12/(1.+exp((svolt-60.)/20.));
+    TAU_Xr2=axr2*bxr2;
+
+    Xs_INF=1./(1.+exp((-5.-svolt)/14.));
+    Axs=1100./(sqrt(1.+exp((-10.-svolt)/6)));
+    Bxs=1./(1.+exp((svolt-60.)/20.));
+    TAU_Xs=Axs*Bxs;
+
+// [!] Myocardium cell
+    R_INF=1./(1.+exp((20-svolt)/6.));
+    S_INF=1./(1.+exp((svolt+20)/5.));
+    TAU_R=9.5*exp(-(svolt+40.)*(svolt+40.)/1800.)+0.8;
+    TAU_S=85.*exp(-(svolt+45.)*(svolt+45.)/320.)+5./(1.+exp((svolt-20.)/5.))+3.;
+
+
+    D_INF=1./(1.+exp((-5-svolt)/7.5));
+    Ad=1.4/(1.+exp((-35-svolt)/13))+0.25;
+    Bd=1.4/(1.+exp((svolt+5)/5));
+    Cd=1./(1.+exp((50-svolt)/20));
+    TAU_D=Ad*Bd+Cd;
+    F_INF=1./(1.+exp((svolt+20)/7));
+    TAU_F=1125*exp(-(svolt+27)*(svolt+27)/300)+80+165/(1.+exp((25-svolt)/10));
+
+
+    FCa_INF=(1./(1.+pow((Cai/0.000325),8))+
+             0.1/(1.+exp((Cai-0.0005)/0.0001))+
+             0.20/(1.+exp((Cai-0.00075)/0.0008))+
+             0.23 )/1.46;
+    if(Cai<0.00035)
+        G_INF=1./(1.+pow((Cai/0.00035),6));
+    else
+        G_INF=1./(1.+pow((Cai/0.00035),16));
+
+    //Update gates
+    rDY_[1]  = M_INF-(M_INF-sm)*exp(-dt/TAU_M);
+    rDY_[2]  = H_INF-(H_INF-sh)*exp(-dt/TAU_H);
+    rDY_[3]  = J_INF-(J_INF-sj)*exp(-dt/TAU_J);
+    rDY_[4]  = Xr1_INF-(Xr1_INF-sxr1)*exp(-dt/TAU_Xr1);
+    rDY_[5]  = Xr2_INF-(Xr2_INF-sxr2)*exp(-dt/TAU_Xr2);
+    rDY_[6]  = Xs_INF-(Xs_INF-sxs)*exp(-dt/TAU_Xs);
+    rDY_[7]  = S_INF-(S_INF-ss)*exp(-dt/TAU_S);
+    rDY_[8]  = R_INF-(R_INF-sr)*exp(-dt/TAU_R);
+    rDY_[9]  = D_INF-(D_INF-sd)*exp(-dt/TAU_D);
+    rDY_[10] = F_INF-(F_INF-sf)*exp(-dt/TAU_F);
+    fcaold= sfca;
+    sfca = FCa_INF-(FCa_INF-sfca)*exptaufca;
+    if(sfca>fcaold && (svolt)>-37.0)
+        sfca = fcaold;
+    gold = sg;
+    sg = G_INF-(G_INF-sg)*exptaug;
+
+    if(sg>gold && (svolt)>-37.0)
+        sg=gold;
+
+    //update voltage
+    rDY_[0] = svolt + dt*(-sItot);
+    rDY_[11] = sfca;
+    rDY_[12] = sg;
+    rDY_[13] = Cai;
+    rDY_[14] = CaSR;
+    rDY_[15] = Nai;
+    rDY_[16] = Ki;    
+
+}
+
+void solve_model_ode_cpu_epi (real dt, real *sv, real stim_current)
+{
+
+    real rY[NEQ], rDY[NEQ];
+
+    for(int i = 0; i < NEQ; i++)
+        rY[i] = sv[i];
+
+    RHS_cpu_epi(rY, rDY, stim_current, dt);
+
+    for(int i = 0; i < NEQ; i++)
+        sv[i] = rDY[i];
+}
+
+void RHS_cpu_epi(const real *sv, real *rDY_, real stim_current, real dt)
+{
+    // State variables
+    real svolt = sv[0];
+    real sm    = sv[1];
+    real sh    = sv[2];
+    real sj    = sv[3];
+    real sxr1  = sv[4];
+    real sxr2  = sv[5];
+    real sxs   = sv[6];
+    real ss    = sv[7];
+    real sr    = sv[8];
+    real sd    = sv[9];
+    real sf    = sv[10];
+    real sfca  = sv[11];
+    real sg    = sv[12];
+    real Cai   = sv[13];
+    real CaSR  = sv[14];
+    real Nai   = sv[15];
+    real Ki    = sv[16];
+
+    //External concentrations
+    real Ko=5.4;
+    real Cao=2.0;
+    real Nao=140.0;
+
+    //Intracellular volumes
+    real Vc=0.016404;
+    real Vsr=0.001094;
+
+    //Calcium dynamics
+    real Bufc=0.15f;
+    real Kbufc=0.001f;
+    real Bufsr=10.f;
+    real Kbufsr=0.3f;
+    real taufca=2.f;
+    real taug=2.f;
+    real Vmaxup=0.000425f;
+    real Kup=0.00025f;
+
+    //Constants
+    const real R = 8314.472f;
+    const real F = 96485.3415f;
+    const real T =310.0f;
+    real RTONF   =(R*T)/F;
+
+    //Cellular capacitance         
+    real CAPACITANCE=0.185;
+
+    //Parameters for currents
+    //Parameters for IKr
+    real Gkr=0.096;
+    //Parameters for Iks
+    real pKNa=0.03;
+    // [!] Epicardium cell
+    real Gks=0.245;
+    //Parameters for Ik1
+    real GK1=5.405;
+    //Parameters for Ito
+// [!] Epicardium cell
+    real Gto=0.294;
+//Parameters for INa
+    real GNa=14.838;
+//Parameters for IbNa
+    real GbNa=0.00029;
+//Parameters for INaK
+    real KmK=1.0;
+    real KmNa=40.0;
+    real knak=1.362;
+//Parameters for ICaL
+    real GCaL=0.000175;
+//Parameters for IbCa
+    real GbCa=0.000592;
+//Parameters for INaCa
+    real knaca=1000;
+    real KmNai=87.5;
+    real KmCa=1.38;
+    real ksat=0.1;
+    real n=0.35;
+//Parameters for IpCa
+    real GpCa=0.825;
+    real KpCa=0.0005;
+//Parameters for IpK;
+    real GpK=0.0146;
+
+
+    real IKr;
+    real IKs;
+    real IK1;
+    real Ito;
+    real INa;
+    real IbNa;
+    real ICaL;
+    real IbCa;
+    real INaCa;
+    real IpCa;
+    real IpK;
+    real INaK;
+    real Irel;
+    real Ileak;
+
+
+    real dNai;
+    real dKi;
+    real dCai;
+    real dCaSR;
+
+    real A;
+//    real BufferFactorc;
+//    real BufferFactorsr;
+    real SERCA;
+    real Caisquare;
+    real CaSRsquare;
+    real CaCurrent;
+    real CaSRCurrent;
+
+
+    real fcaold;
+    real gold;
+    real Ek;
+    real Ena;
+    real Eks;
+    real Eca;
+    real CaCSQN;
+    real bjsr;
+    real cjsr;
+    real CaBuf;
+    real bc;
+    real cc;
+    real Ak1;
+    real Bk1;
+    real rec_iK1;
+    real rec_ipK;
+    real rec_iNaK;
+    real AM;
+    real BM;
+    real AH_1;
+    real BH_1;
+    real AH_2;
+    real BH_2;
+    real AJ_1;
+    real BJ_1;
+    real AJ_2;
+    real BJ_2;
+    real M_INF;
+    real H_INF;
+    real J_INF;
+    real TAU_M;
+    real TAU_H;
+    real TAU_J;
+    real axr1;
+    real bxr1;
+    real axr2;
+    real bxr2;
+    real Xr1_INF;
+    real Xr2_INF;
+    real TAU_Xr1;
+    real TAU_Xr2;
+    real Axs;
+    real Bxs;
+    real Xs_INF;
+    real TAU_Xs;
+    real R_INF;
+    real TAU_R;
+    real S_INF;
+    real TAU_S;
+    real Ad;
+    real Bd;
+    real Cd;
+    real TAU_D;
+    real D_INF;
+    real TAU_F;
+    real F_INF;
+    real FCa_INF;
+    real G_INF;
+
+    real inverseVcF2=1/(2*Vc*F);
+    real inverseVcF=1./(Vc*F);
+    real Kupsquare=Kup*Kup;
+//    real BufcKbufc=Bufc*Kbufc;
+//    real Kbufcsquare=Kbufc*Kbufc;
+//    real Kbufc2=2*Kbufc;
+//    real BufsrKbufsr=Bufsr*Kbufsr;
+//    const real Kbufsrsquare=Kbufsr*Kbufsr;
+//    const real Kbufsr2=2*Kbufsr;
+    const real exptaufca=exp(-dt/taufca);
+    const real exptaug=exp(-dt/taug);
+
+    real sItot;
+
+    //Needed to compute currents
+    Ek=RTONF*(log((Ko/Ki)));
+    Ena=RTONF*(log((Nao/Nai)));
+    Eks=RTONF*(log((Ko+pKNa*Nao)/(Ki+pKNa*Nai)));
+    Eca=0.5*RTONF*(log((Cao/Cai)));
+    Ak1=0.1/(1.+exp(0.06*(svolt-Ek-200)));
+    Bk1=(3.*exp(0.0002*(svolt-Ek+100))+
+         exp(0.1*(svolt-Ek-10)))/(1.+exp(-0.5*(svolt-Ek)));
+    rec_iK1=Ak1/(Ak1+Bk1);
+    rec_iNaK=(1./(1.+0.1245*exp(-0.1*svolt*F/(R*T))+0.0353*exp(-svolt*F/(R*T))));
+    rec_ipK=1./(1.+exp((25-svolt)/5.98));
+
+
+    //Compute currents
+    INa=GNa*sm*sm*sm*sh*sj*(svolt-Ena);
+    ICaL=GCaL*sd*sf*sfca*4*svolt*(F*F/(R*T))*
+         (exp(2*svolt*F/(R*T))*Cai-0.341*Cao)/(exp(2*svolt*F/(R*T))-1.);
+    Ito=Gto*sr*ss*(svolt-Ek);
+    IKr=Gkr*sqrt(Ko/5.4)*sxr1*sxr2*(svolt-Ek);
+    IKs=Gks*sxs*sxs*(svolt-Eks);
+    IK1=GK1*rec_iK1*(svolt-Ek);
+    INaCa=knaca*(1./(KmNai*KmNai*KmNai+Nao*Nao*Nao))*(1./(KmCa+Cao))*
+          (1./(1+ksat*exp((n-1)*svolt*F/(R*T))))*
+          (exp(n*svolt*F/(R*T))*Nai*Nai*Nai*Cao-
+           exp((n-1)*svolt*F/(R*T))*Nao*Nao*Nao*Cai*2.5);
+    INaK=knak*(Ko/(Ko+KmK))*(Nai/(Nai+KmNa))*rec_iNaK;
+    IpCa=GpCa*Cai/(KpCa+Cai);
+    IpK=GpK*rec_ipK*(svolt-Ek);
+    IbNa=GbNa*(svolt-Ena);
+    IbCa=GbCa*(svolt-Eca);
+
+
+    //Determine total current
+    (sItot) = IKr    +
+              IKs   +
+              IK1   +
+              Ito   +
+              INa   +
+              IbNa  +
+              ICaL  +
+              IbCa  +
+              INaK  +
+              INaCa +
+              IpCa  +
+              IpK   +
+              stim_current;
+
+
+    //update concentrations
+    Caisquare=Cai*Cai;
+    CaSRsquare=CaSR*CaSR;
+    CaCurrent=-(ICaL+IbCa+IpCa-2.0f*INaCa)*inverseVcF2*CAPACITANCE;
+    A=0.016464f*CaSRsquare/(0.0625f+CaSRsquare)+0.008232f;
+    Irel=A*sd*sg;
+    Ileak=0.00008f*(CaSR-Cai);
+    SERCA=Vmaxup/(1.f+(Kupsquare/Caisquare));
+    CaSRCurrent=SERCA-Irel-Ileak;
+    CaCSQN=Bufsr*CaSR/(CaSR+Kbufsr);
+    dCaSR=dt*(Vc/Vsr)*CaSRCurrent;
+    bjsr=Bufsr-CaCSQN-dCaSR-CaSR+Kbufsr;
+    cjsr=Kbufsr*(CaCSQN+dCaSR+CaSR);
+    CaSR=(sqrt(bjsr*bjsr+4.*cjsr)-bjsr)/2.;
+    CaBuf=Bufc*Cai/(Cai+Kbufc);
+    dCai=dt*(CaCurrent-CaSRCurrent);
+    bc=Bufc-CaBuf-dCai-Cai+Kbufc;
+    cc=Kbufc*(CaBuf+dCai+Cai);
+    Cai=(sqrt(bc*bc+4*cc)-bc)/2;
+
+
+
+    dNai=-(INa+IbNa+3*INaK+3*INaCa)*inverseVcF*CAPACITANCE;
+    Nai+=dt*dNai;
+
+    dKi=-(stim_current+IK1+Ito+IKr+IKs-2*INaK+IpK)*inverseVcF*CAPACITANCE;
+    Ki+=dt*dKi;
+
+    //compute steady state values and time constants
+    AM=1./(1.+exp((-60.-svolt)/5.));
+    BM=0.1/(1.+exp((svolt+35.)/5.))+0.10/(1.+exp((svolt-50.)/200.));
+    TAU_M=AM*BM;
+    M_INF=1./((1.+exp((-56.86-svolt)/9.03))*(1.+exp((-56.86-svolt)/9.03)));
+    if (svolt>=-40.)
+    {
+        AH_1=0.;
+        BH_1=(0.77/(0.13*(1.+exp(-(svolt+10.66)/11.1))));
+        TAU_H= 1.0/(AH_1+BH_1);
+    }
+    else
+    {
+        AH_2=(0.057*exp(-(svolt+80.)/6.8));
+        BH_2=(2.7*exp(0.079*svolt)+(3.1e5)*exp(0.3485*svolt));
+        TAU_H=1.0/(AH_2+BH_2);
+    }
+    H_INF=1./((1.+exp((svolt+71.55)/7.43))*(1.+exp((svolt+71.55)/7.43)));
+    if(svolt>=-40.)
+    {
+        AJ_1=0.;
+        BJ_1=(0.6*exp((0.057)*svolt)/(1.+exp(-0.1*(svolt+32.))));
+        TAU_J= 1.0/(AJ_1+BJ_1);
+    }
+    else
+    {
+        AJ_2=(((-2.5428e4)*exp(0.2444*svolt)-(6.948e-6)*
+                                             exp(-0.04391*svolt))*(svolt+37.78)/
+              (1.+exp(0.311*(svolt+79.23))));
+        BJ_2=(0.02424*exp(-0.01052*svolt)/(1.+exp(-0.1378*(svolt+40.14))));
+        TAU_J= 1.0/(AJ_2+BJ_2);
+    }
+    J_INF=H_INF;
+
+    Xr1_INF=1./(1.+exp((-26.-svolt)/7.));
+    axr1=450./(1.+exp((-45.-svolt)/10.));
+    bxr1=6./(1.+exp((svolt-(-30.))/11.5));
+    TAU_Xr1=axr1*bxr1;
+    Xr2_INF=1./(1.+exp((svolt-(-88.))/24.));
+    axr2=3./(1.+exp((-60.-svolt)/20.));
+    bxr2=1.12/(1.+exp((svolt-60.)/20.));
+    TAU_Xr2=axr2*bxr2;
+
+    Xs_INF=1./(1.+exp((-5.-svolt)/14.));
+    Axs=1100./(sqrt(1.+exp((-10.-svolt)/6)));
+    Bxs=1./(1.+exp((svolt-60.)/20.));
+    TAU_Xs=Axs*Bxs;
+
+    R_INF=1./(1.+exp((20-svolt)/6.));
+    S_INF=1./(1.+exp((svolt+20)/5.));
+    TAU_R=9.5*exp(-(svolt+40.)*(svolt+40.)/1800.)+0.8;
+    TAU_S=85.*exp(-(svolt+45.)*(svolt+45.)/320.)+5./(1.+exp((svolt-20.)/5.))+3.;
+
+
+    D_INF=1./(1.+exp((-5-svolt)/7.5));
+    Ad=1.4/(1.+exp((-35-svolt)/13))+0.25;
+    Bd=1.4/(1.+exp((svolt+5)/5));
+    Cd=1./(1.+exp((50-svolt)/20));
+    TAU_D=Ad*Bd+Cd;
+    F_INF=1./(1.+exp((svolt+20)/7));
+    TAU_F=1125*exp(-(svolt+27)*(svolt+27)/300)+80+165/(1.+exp((25-svolt)/10));
+
+
+    FCa_INF=(1./(1.+pow((Cai/0.000325),8))+
+             0.1/(1.+exp((Cai-0.0005)/0.0001))+
+             0.20/(1.+exp((Cai-0.00075)/0.0008))+
+             0.23 )/1.46;
+    if(Cai<0.00035)
+        G_INF=1./(1.+pow((Cai/0.00035),6));
+    else
+        G_INF=1./(1.+pow((Cai/0.00035),16));
+
+    //Update gates
+    rDY_[1]  = M_INF-(M_INF-sm)*exp(-dt/TAU_M);
+    rDY_[2]  = H_INF-(H_INF-sh)*exp(-dt/TAU_H);
+    rDY_[3]  = J_INF-(J_INF-sj)*exp(-dt/TAU_J);
+    rDY_[4]  = Xr1_INF-(Xr1_INF-sxr1)*exp(-dt/TAU_Xr1);
+    rDY_[5]  = Xr2_INF-(Xr2_INF-sxr2)*exp(-dt/TAU_Xr2);
+    rDY_[6]  = Xs_INF-(Xs_INF-sxs)*exp(-dt/TAU_Xs);
+    rDY_[7]  = S_INF-(S_INF-ss)*exp(-dt/TAU_S);
+    rDY_[8]  = R_INF-(R_INF-sr)*exp(-dt/TAU_R);
+    rDY_[9]  = D_INF-(D_INF-sd)*exp(-dt/TAU_D);
+    rDY_[10] = F_INF-(F_INF-sf)*exp(-dt/TAU_F);
+    fcaold= sfca;
+    sfca = FCa_INF-(FCa_INF-sfca)*exptaufca;
+    if(sfca>fcaold && (svolt)>-37.0)
+        sfca = fcaold;
+    gold = sg;
+    sg = G_INF-(G_INF-sg)*exptaug;
+
+    if(sg>gold && (svolt)>-37.0)
+        sg=gold;
+
+    //update voltage
+    rDY_[0] = svolt + dt*(-sItot);
+    rDY_[11] = sfca;
+    rDY_[12] = sg;
+    rDY_[13] = Cai;
+    rDY_[14] = CaSR;
+    rDY_[15] = Nai;
+    rDY_[16] = Ki;    
+}

--- a/src/models_library/ten_tusscher/mixed_tentusscher_myo_epi_2004.cu
+++ b/src/models_library/ten_tusscher/mixed_tentusscher_myo_epi_2004.cu
@@ -1,0 +1,928 @@
+#include <stddef.h>
+#include <stdint.h>
+
+#include "mixed_tentusscher_myo_epi_2004.h"
+
+__constant__ size_t pitch;
+size_t pitch_h;
+
+extern "C" SET_ODE_INITIAL_CONDITIONS_GPU(set_model_initial_conditions_gpu) 
+{
+
+    log_to_stdout_and_file("Using mixed version of TenTusscher 2004 myocardium + epicardium GPU model\n\n");
+
+    uint32_t num_volumes = solver->original_num_cells;
+
+    // execution configuration
+    const int GRID  = (num_volumes + BLOCK_SIZE - 1)/BLOCK_SIZE;
+
+    size_t size = num_volumes*sizeof(real);
+
+    check_cuda_error(cudaMallocPitch((void **) &(solver->sv), &pitch_h, size, (size_t )NEQ));
+    check_cuda_error(cudaMemcpyToSymbol(pitch, &pitch_h, sizeof(size_t)));
+
+    // Get the mapping array
+    uint32_t *mapping = NULL;
+    uint32_t *mapping_device = NULL;
+    if(solver->ode_extra_data) 
+    {
+        mapping = (uint32_t*)solver->ode_extra_data;
+        check_cuda_error(cudaMalloc((void **)&mapping_device, solver->extra_data_size));
+        check_cuda_error(cudaMemcpy(mapping_device, mapping, solver->extra_data_size, cudaMemcpyHostToDevice));
+    }
+
+    kernel_set_model_inital_conditions <<<GRID, BLOCK_SIZE>>>(solver->sv, mapping_device, num_volumes);
+
+    check_cuda_error( cudaPeekAtLastError() );
+    cudaDeviceSynchronize();
+    
+    check_cuda_error(cudaFree(mapping_device));
+
+    return pitch_h;
+
+}
+
+extern "C" SOLVE_MODEL_ODES(solve_model_odes_gpu) 
+{
+
+	size_t num_cells_to_solve = ode_solver->num_cells_to_solve;
+    uint32_t *cells_to_solve = ode_solver->cells_to_solve;
+    real *sv = ode_solver->sv;
+    real dt = ode_solver->min_dt;
+    uint32_t num_steps = ode_solver->num_steps;
+
+
+    // execution configuration
+    const int GRID  = ((int)num_cells_to_solve + BLOCK_SIZE - 1)/BLOCK_SIZE;
+
+    size_t stim_currents_size = sizeof(real)*num_cells_to_solve;
+    size_t cells_to_solve_size = sizeof(uint32_t)*num_cells_to_solve;
+
+    real *stims_currents_device;
+    check_cuda_error(cudaMalloc((void **) &stims_currents_device, stim_currents_size));
+    check_cuda_error(cudaMemcpy(stims_currents_device, stim_currents, stim_currents_size, cudaMemcpyHostToDevice));
+
+
+    //the array cells to solve is passed when we are using and adapative mesh
+    uint32_t *cells_to_solve_device = NULL;
+    if(cells_to_solve != NULL) 
+    {
+        check_cuda_error(cudaMalloc((void **) &cells_to_solve_device, cells_to_solve_size));
+        check_cuda_error(cudaMemcpy(cells_to_solve_device, cells_to_solve, cells_to_solve_size, cudaMemcpyHostToDevice));
+    }
+
+    // Get the mapping array
+    uint32_t *mapping = NULL;
+    uint32_t *mapping_device = NULL;
+    if(ode_solver->ode_extra_data) 
+    {
+        mapping = (uint32_t*)ode_solver->ode_extra_data;
+        check_cuda_error(cudaMalloc((void **)&mapping_device, ode_solver->extra_data_size));
+        check_cuda_error(cudaMemcpy(mapping_device, mapping, ode_solver->extra_data_size, cudaMemcpyHostToDevice));
+    }
+    else 
+    {
+        log_to_stderr_and_file_and_exit("You need to specify a mask function when using a mixed model!\n");
+    }
+
+    solve_gpu <<<GRID, BLOCK_SIZE>>>(dt, sv, stims_currents_device, cells_to_solve_device, mapping_device, num_cells_to_solve, num_steps);
+
+    check_cuda_error( cudaPeekAtLastError() );
+
+    check_cuda_error(cudaFree(stims_currents_device));
+    if(cells_to_solve_device) check_cuda_error(cudaFree(cells_to_solve_device));
+    if(mapping_device) check_cuda_error(cudaFree(mapping_device));
+
+}
+
+__global__ void kernel_set_model_inital_conditions(real *sv, uint32_t *mapping, int num_volumes) 
+{
+    int threadID = blockDim.x * blockIdx.x + threadIdx.x;
+
+    if (threadID < num_volumes) 
+    {
+
+        // Initial conditions for TenTusscher 2004 myocardium
+        if (mapping[threadID] == 0)
+        {
+            *((real * )((char *) sv + pitch * 0) + threadID) =  INITIAL_V;     // V;       millivolt
+            *((real * )((char *) sv + pitch * 1) + threadID) =  0.f;           //M
+            *((real * )((char *) sv + pitch * 2) + threadID) =  0.75;          //H
+            *((real * )((char *) sv + pitch * 3) + threadID) =  0.75f;         //J
+            *((real * )((char *) sv + pitch * 4) + threadID) =  0.f;           //Xr1
+            *((real * )((char *) sv + pitch * 5) + threadID) =  1.f;           //Xr2
+            *((real * )((char *) sv + pitch * 6) + threadID) =  0.f;           //Xs
+            *((real * )((char *) sv + pitch * 7) + threadID) =  1.f;           //S
+            *((real * )((char *) sv + pitch * 8) + threadID) =  0.f;           //R
+            *((real * )((char *) sv + pitch * 9) + threadID) =  0.f;           //D
+            *((real * )((char *) sv + pitch * 10) + threadID) = 1.f;           //F
+            *((real * )((char *) sv + pitch * 11) + threadID) = 1.f;           //FCa
+            *((real * )((char *) sv + pitch * 12) + threadID) = 1.f;           //G
+            *((real * )((char *) sv + pitch * 13) + threadID) = 0.0002;        //Cai
+            *((real * )((char *) sv + pitch * 14) + threadID) = 0.2f;          //CaSR
+            *((real * )((char *) sv + pitch * 15) + threadID) = 11.6f;         //Nai
+            *((real * )((char *) sv + pitch * 16) + threadID) = 138.3f;        //Ki
+        }
+        // Initial conditions for TenTusscher 2004 epicardium
+        else
+        {
+            *((real * )((char *) sv + pitch * 0) + threadID) =  INITIAL_V;     // V;       millivolt
+            *((real * )((char *) sv + pitch * 1) + threadID) =  0.f;           //M
+            *((real * )((char *) sv + pitch * 2) + threadID) =  0.75;          //H
+            *((real * )((char *) sv + pitch * 3) + threadID) =  0.75f;         //J
+            *((real * )((char *) sv + pitch * 4) + threadID) =  0.f;           //Xr1
+            *((real * )((char *) sv + pitch * 5) + threadID) =  1.f;           //Xr2
+            *((real * )((char *) sv + pitch * 6) + threadID) =  0.f;           //Xs
+            *((real * )((char *) sv + pitch * 7) + threadID) =  1.f;           //S
+            *((real * )((char *) sv + pitch * 8) + threadID) =  0.f;           //R
+            *((real * )((char *) sv + pitch * 9) + threadID) =  0.f;           //D
+            *((real * )((char *) sv + pitch * 10) + threadID) = 1.f;           //F
+            *((real * )((char *) sv + pitch * 11) + threadID) = 1.f;           //FCa
+            *((real * )((char *) sv + pitch * 12) + threadID) = 1.f;           //G
+            *((real * )((char *) sv + pitch * 13) + threadID) = 0.0002;        //Cai
+            *((real * )((char *) sv + pitch * 14) + threadID) = 0.2f;          //CaSR
+            *((real * )((char *) sv + pitch * 15) + threadID) = 11.6f;         //Nai
+            *((real * )((char *) sv + pitch * 16) + threadID) = 138.3f;        //Ki
+        }
+    }
+}
+
+// Solving the model for each cell in the tissue matrix ni x nj
+__global__ void solve_gpu(real dt, real *sv, real* stim_currents,
+                          uint32_t *cells_to_solve, uint32_t *mapping, uint32_t num_cells_to_solve,
+                          int num_steps)
+{
+    int threadID = blockDim.x * blockIdx.x + threadIdx.x;
+    int sv_id;
+
+    // Each thread solves one cell model
+    if(threadID < num_cells_to_solve) 
+    {
+        if(cells_to_solve)
+            sv_id = cells_to_solve[threadID];
+        else
+            sv_id = threadID;
+
+        real rDY[NEQ];
+
+		for (int n = 0; n < num_steps; ++n) {
+
+			if (mapping[sv_id] == 0) {
+				RHS_gpu_myo(sv, rDY, stim_currents[threadID], sv_id, dt);
+			}
+			else {
+				RHS_gpu_epi(sv, rDY, stim_currents[threadID], sv_id, dt);
+			}
+
+            for(int i = 0; i < NEQ; i++) {
+                *((real*)((char*)sv + pitch * i) + sv_id) = rDY[i];
+            }
+
+		}
+
+    }
+}
+
+inline __device__ void RHS_gpu_myo (real *sv_, real *rDY_, real stim_current, int threadID_, real dt) 
+{
+
+    // State variables
+    real svolt = *((real*)((char*)sv_ + pitch * 0) + threadID_);
+    real sm    = *((real*)((char*)sv_ + pitch * 1) + threadID_);
+    real sh    = *((real*)((char*)sv_ + pitch * 2) + threadID_);
+    real sj    = *((real*)((char*)sv_ + pitch * 3) + threadID_);
+    real sxr1  = *((real*)((char*)sv_ + pitch * 4) + threadID_);
+    real sxr2  = *((real*)((char*)sv_ + pitch * 5) + threadID_);
+    real sxs   = *((real*)((char*)sv_ + pitch * 6) + threadID_);
+    real ss    = *((real*)((char*)sv_ + pitch * 7) + threadID_);
+    real sr    = *((real*)((char*)sv_ + pitch * 8) + threadID_);
+    real sd    = *((real*)((char*)sv_ + pitch * 9) + threadID_);
+    real sf    = *((real*)((char*)sv_ + pitch * 10) + threadID_);
+    real sfca  = *((real*)((char*)sv_ + pitch * 11) + threadID_);
+    real sg    = *((real*)((char*)sv_ + pitch * 12) + threadID_);
+    real Cai   = *((real*)((char*)sv_ + pitch * 13) + threadID_);
+    real CaSR  = *((real*)((char*)sv_ + pitch * 14) + threadID_);
+    real Nai   = *((real*)((char*)sv_ + pitch * 15) + threadID_);
+    real Ki    = *((real*)((char*)sv_ + pitch * 16) + threadID_);
+
+    //External concentrations
+    real Ko=5.4;
+    real Cao=2.0;
+    real Nao=140.0;
+
+    //Intracellular volumes
+    real Vc=0.016404;
+    real Vsr=0.001094;
+
+    //Calcium dynamics
+    real Bufc=0.15f;
+    real Kbufc=0.001f;
+    real Bufsr=10.f;
+    real Kbufsr=0.3f;
+    real taufca=2.f;
+    real taug=2.f;
+    real Vmaxup=0.000425f;
+    real Kup=0.00025f;
+
+    //Constants
+    const real R = 8314.472f;
+    const real F = 96485.3415f;
+    const real T =310.0f;
+    real RTONF   =(R*T)/F;
+
+    //Cellular capacitance         
+    real CAPACITANCE=0.185;
+
+    //Parameters for currents
+    //Parameters for IKr
+    real Gkr=0.096;
+    //Parameters for Iks
+    real pKNa=0.03;
+
+// [!] Myocardium cell
+    real Gks=0.062;
+//Parameters for Ik1
+    real GK1=5.405;
+//Parameters for Ito
+// [!] Myocardium cell
+    real Gto=0.294;
+//Parameters for INa
+    real GNa=14.838;
+//Parameters for IbNa
+    real GbNa=0.00029;
+//Parameters for INaK
+    real KmK=1.0;
+    real KmNa=40.0;
+    real knak=1.362;
+//Parameters for ICaL
+    real GCaL=0.000175;
+//Parameters for IbCa
+    real GbCa=0.000592;
+//Parameters for INaCa
+    real knaca=1000;
+    real KmNai=87.5;
+    real KmCa=1.38;
+    real ksat=0.1;
+    real n=0.35;
+//Parameters for IpCa
+    real GpCa=0.825;
+    real KpCa=0.0005;
+//Parameters for IpK;
+    real GpK=0.0146;
+
+
+    real IKr;
+    real IKs;
+    real IK1;
+    real Ito;
+    real INa;
+    real IbNa;
+    real ICaL;
+    real IbCa;
+    real INaCa;
+    real IpCa;
+    real IpK;
+    real INaK;
+    real Irel;
+    real Ileak;
+
+
+    real dNai;
+    real dKi;
+    real dCai;
+    real dCaSR;
+
+    real A;
+//    real BufferFactorc;
+//    real BufferFactorsr;
+    real SERCA;
+    real Caisquare;
+    real CaSRsquare;
+    real CaCurrent;
+    real CaSRCurrent;
+
+
+    real fcaold;
+    real gold;
+    real Ek;
+    real Ena;
+    real Eks;
+    real Eca;
+    real CaCSQN;
+    real bjsr;
+    real cjsr;
+    real CaBuf;
+    real bc;
+    real cc;
+    real Ak1;
+    real Bk1;
+    real rec_iK1;
+    real rec_ipK;
+    real rec_iNaK;
+    real AM;
+    real BM;
+    real AH_1;
+    real BH_1;
+    real AH_2;
+    real BH_2;
+    real AJ_1;
+    real BJ_1;
+    real AJ_2;
+    real BJ_2;
+    real M_INF;
+    real H_INF;
+    real J_INF;
+    real TAU_M;
+    real TAU_H;
+    real TAU_J;
+    real axr1;
+    real bxr1;
+    real axr2;
+    real bxr2;
+    real Xr1_INF;
+    real Xr2_INF;
+    real TAU_Xr1;
+    real TAU_Xr2;
+    real Axs;
+    real Bxs;
+    real Xs_INF;
+    real TAU_Xs;
+    real R_INF;
+    real TAU_R;
+    real S_INF;
+    real TAU_S;
+    real Ad;
+    real Bd;
+    real Cd;
+    real TAU_D;
+    real D_INF;
+    real TAU_F;
+    real F_INF;
+    real FCa_INF;
+    real G_INF;
+
+    real inverseVcF2=1/(2*Vc*F);
+    real inverseVcF=1./(Vc*F);
+    real Kupsquare=Kup*Kup;
+//    real BufcKbufc=Bufc*Kbufc;
+//    real Kbufcsquare=Kbufc*Kbufc;
+//    real Kbufc2=2*Kbufc;
+//    real BufsrKbufsr=Bufsr*Kbufsr;
+//    const real Kbufsrsquare=Kbufsr*Kbufsr;
+//    const real Kbufsr2=2*Kbufsr;
+    const real exptaufca=exp(-dt/taufca);
+    const real exptaug=exp(-dt/taug);
+
+    real sItot;
+
+    //Needed to compute currents
+    Ek=RTONF*(log((Ko/Ki)));
+    Ena=RTONF*(log((Nao/Nai)));
+    Eks=RTONF*(log((Ko+pKNa*Nao)/(Ki+pKNa*Nai)));
+    Eca=0.5*RTONF*(log((Cao/Cai)));
+    Ak1=0.1/(1.+exp(0.06*(svolt-Ek-200)));
+    Bk1=(3.*exp(0.0002*(svolt-Ek+100))+
+         exp(0.1*(svolt-Ek-10)))/(1.+exp(-0.5*(svolt-Ek)));
+    rec_iK1=Ak1/(Ak1+Bk1);
+    rec_iNaK=(1./(1.+0.1245*exp(-0.1*svolt*F/(R*T))+0.0353*exp(-svolt*F/(R*T))));
+    rec_ipK=1./(1.+exp((25-svolt)/5.98));
+
+
+    //Compute currents
+    INa=GNa*sm*sm*sm*sh*sj*(svolt-Ena);
+    ICaL=GCaL*sd*sf*sfca*4*svolt*(F*F/(R*T))*
+         (exp(2*svolt*F/(R*T))*Cai-0.341*Cao)/(exp(2*svolt*F/(R*T))-1.);
+    Ito=Gto*sr*ss*(svolt-Ek);
+    IKr=Gkr*sqrt(Ko/5.4)*sxr1*sxr2*(svolt-Ek);
+    IKs=Gks*sxs*sxs*(svolt-Eks);
+    IK1=GK1*rec_iK1*(svolt-Ek);
+    INaCa=knaca*(1./(KmNai*KmNai*KmNai+Nao*Nao*Nao))*(1./(KmCa+Cao))*
+          (1./(1+ksat*exp((n-1)*svolt*F/(R*T))))*
+          (exp(n*svolt*F/(R*T))*Nai*Nai*Nai*Cao-
+           exp((n-1)*svolt*F/(R*T))*Nao*Nao*Nao*Cai*2.5);
+    INaK=knak*(Ko/(Ko+KmK))*(Nai/(Nai+KmNa))*rec_iNaK;
+    IpCa=GpCa*Cai/(KpCa+Cai);
+    IpK=GpK*rec_ipK*(svolt-Ek);
+    IbNa=GbNa*(svolt-Ena);
+    IbCa=GbCa*(svolt-Eca);
+
+
+    //Determine total current
+    (sItot) = IKr    +
+              IKs   +
+              IK1   +
+              Ito   +
+              INa   +
+              IbNa  +
+              ICaL  +
+              IbCa  +
+              INaK  +
+              INaCa +
+              IpCa  +
+              IpK   +
+              stim_current;
+
+
+    //update concentrations
+    Caisquare=Cai*Cai;
+    CaSRsquare=CaSR*CaSR;
+    CaCurrent=-(ICaL+IbCa+IpCa-2.0f*INaCa)*inverseVcF2*CAPACITANCE;
+    A=0.016464f*CaSRsquare/(0.0625f+CaSRsquare)+0.008232f;
+    Irel=A*sd*sg;
+    Ileak=0.00008f*(CaSR-Cai);
+    SERCA=Vmaxup/(1.f+(Kupsquare/Caisquare));
+    CaSRCurrent=SERCA-Irel-Ileak;
+    CaCSQN=Bufsr*CaSR/(CaSR+Kbufsr);
+    dCaSR=dt*(Vc/Vsr)*CaSRCurrent;
+    bjsr=Bufsr-CaCSQN-dCaSR-CaSR+Kbufsr;
+    cjsr=Kbufsr*(CaCSQN+dCaSR+CaSR);
+    CaSR=(sqrt(bjsr*bjsr+4.*cjsr)-bjsr)/2.;
+    CaBuf=Bufc*Cai/(Cai+Kbufc);
+    dCai=dt*(CaCurrent-CaSRCurrent);
+    bc=Bufc-CaBuf-dCai-Cai+Kbufc;
+    cc=Kbufc*(CaBuf+dCai+Cai);
+    Cai=(sqrt(bc*bc+4*cc)-bc)/2;
+
+
+
+    dNai=-(INa+IbNa+3*INaK+3*INaCa)*inverseVcF*CAPACITANCE;
+    Nai+=dt*dNai;
+
+    dKi=-(stim_current+IK1+Ito+IKr+IKs-2*INaK+IpK)*inverseVcF*CAPACITANCE;
+    Ki+=dt*dKi;
+
+    //compute steady state values and time constants
+    AM=1./(1.+exp((-60.-svolt)/5.));
+    BM=0.1/(1.+exp((svolt+35.)/5.))+0.10/(1.+exp((svolt-50.)/200.));
+    TAU_M=AM*BM;
+    M_INF=1./((1.+exp((-56.86-svolt)/9.03))*(1.+exp((-56.86-svolt)/9.03)));
+    if (svolt>=-40.)
+    {
+        AH_1=0.;
+        BH_1=(0.77/(0.13*(1.+exp(-(svolt+10.66)/11.1))));
+        TAU_H= 1.0/(AH_1+BH_1);
+    }
+    else
+    {
+        AH_2=(0.057*exp(-(svolt+80.)/6.8));
+        BH_2=(2.7*exp(0.079*svolt)+(3.1e5)*exp(0.3485*svolt));
+        TAU_H=1.0/(AH_2+BH_2);
+    }
+    H_INF=1./((1.+exp((svolt+71.55)/7.43))*(1.+exp((svolt+71.55)/7.43)));
+    if(svolt>=-40.)
+    {
+        AJ_1=0.;
+        BJ_1=(0.6*exp((0.057)*svolt)/(1.+exp(-0.1*(svolt+32.))));
+        TAU_J= 1.0/(AJ_1+BJ_1);
+    }
+    else
+    {
+        AJ_2=(((-2.5428e4)*exp(0.2444*svolt)-(6.948e-6)*
+                                             exp(-0.04391*svolt))*(svolt+37.78)/
+              (1.+exp(0.311*(svolt+79.23))));
+        BJ_2=(0.02424*exp(-0.01052*svolt)/(1.+exp(-0.1378*(svolt+40.14))));
+        TAU_J= 1.0/(AJ_2+BJ_2);
+    }
+    J_INF=H_INF;
+
+    Xr1_INF=1./(1.+exp((-26.-svolt)/7.));
+    axr1=450./(1.+exp((-45.-svolt)/10.));
+    bxr1=6./(1.+exp((svolt-(-30.))/11.5));
+    TAU_Xr1=axr1*bxr1;
+    Xr2_INF=1./(1.+exp((svolt-(-88.))/24.));
+    axr2=3./(1.+exp((-60.-svolt)/20.));
+    bxr2=1.12/(1.+exp((svolt-60.)/20.));
+    TAU_Xr2=axr2*bxr2;
+
+    Xs_INF=1./(1.+exp((-5.-svolt)/14.));
+    Axs=1100./(sqrt(1.+exp((-10.-svolt)/6)));
+    Bxs=1./(1.+exp((svolt-60.)/20.));
+    TAU_Xs=Axs*Bxs;
+
+// [!] Myocardium cell
+    R_INF=1./(1.+exp((20-svolt)/6.));
+    S_INF=1./(1.+exp((svolt+20)/5.));
+    TAU_R=9.5*exp(-(svolt+40.)*(svolt+40.)/1800.)+0.8;
+    TAU_S=85.*exp(-(svolt+45.)*(svolt+45.)/320.)+5./(1.+exp((svolt-20.)/5.))+3.;
+
+
+    D_INF=1./(1.+exp((-5-svolt)/7.5));
+    Ad=1.4/(1.+exp((-35-svolt)/13))+0.25;
+    Bd=1.4/(1.+exp((svolt+5)/5));
+    Cd=1./(1.+exp((50-svolt)/20));
+    TAU_D=Ad*Bd+Cd;
+    F_INF=1./(1.+exp((svolt+20)/7));
+    TAU_F=1125*exp(-(svolt+27)*(svolt+27)/300)+80+165/(1.+exp((25-svolt)/10));
+
+
+    FCa_INF=(1./(1.+pow((Cai/0.000325),8))+
+             0.1/(1.+exp((Cai-0.0005)/0.0001))+
+             0.20/(1.+exp((Cai-0.00075)/0.0008))+
+             0.23 )/1.46;
+    if(Cai<0.00035)
+        G_INF=1./(1.+pow((Cai/0.00035),6));
+    else
+        G_INF=1./(1.+pow((Cai/0.00035),16));
+
+    //Update gates
+    rDY_[1]  = M_INF-(M_INF-sm)*exp(-dt/TAU_M);
+    rDY_[2]  = H_INF-(H_INF-sh)*exp(-dt/TAU_H);
+    rDY_[3]  = J_INF-(J_INF-sj)*exp(-dt/TAU_J);
+    rDY_[4]  = Xr1_INF-(Xr1_INF-sxr1)*exp(-dt/TAU_Xr1);
+    rDY_[5]  = Xr2_INF-(Xr2_INF-sxr2)*exp(-dt/TAU_Xr2);
+    rDY_[6]  = Xs_INF-(Xs_INF-sxs)*exp(-dt/TAU_Xs);
+    rDY_[7]  = S_INF-(S_INF-ss)*exp(-dt/TAU_S);
+    rDY_[8]  = R_INF-(R_INF-sr)*exp(-dt/TAU_R);
+    rDY_[9]  = D_INF-(D_INF-sd)*exp(-dt/TAU_D);
+    rDY_[10] = F_INF-(F_INF-sf)*exp(-dt/TAU_F);
+    fcaold= sfca;
+    sfca = FCa_INF-(FCa_INF-sfca)*exptaufca;
+    if(sfca>fcaold && (svolt)>-37.0)
+        sfca = fcaold;
+    gold = sg;
+    sg = G_INF-(G_INF-sg)*exptaug;
+
+    if(sg>gold && (svolt)>-37.0)
+        sg=gold;
+
+    //update voltage
+    rDY_[0] = svolt + dt*(-sItot);
+    rDY_[11] = sfca;
+    rDY_[12] = sg;
+    rDY_[13] = Cai;
+    rDY_[14] = CaSR;
+    rDY_[15] = Nai;
+    rDY_[16] = Ki;
+
+}
+
+inline __device__ void RHS_gpu_epi (real *sv_, real *rDY_, real stim_current, int threadID_, real dt)
+{
+    // State variables
+     real svolt = *((real*)((char*)sv_ + pitch * 0) + threadID_);
+     real sm    = *((real*)((char*)sv_ + pitch * 1) + threadID_);
+     real sh    = *((real*)((char*)sv_ + pitch * 2) + threadID_);
+     real sj    = *((real*)((char*)sv_ + pitch * 3) + threadID_);
+     real sxr1  = *((real*)((char*)sv_ + pitch * 4) + threadID_);
+     real sxr2  = *((real*)((char*)sv_ + pitch * 5) + threadID_);
+     real sxs   = *((real*)((char*)sv_ + pitch * 6) + threadID_);
+     real ss    = *((real*)((char*)sv_ + pitch * 7) + threadID_);
+     real sr    = *((real*)((char*)sv_ + pitch * 8) + threadID_);
+     real sd    = *((real*)((char*)sv_ + pitch * 9) + threadID_);
+     real sf    = *((real*)((char*)sv_ + pitch * 10) + threadID_);
+     real sfca  = *((real*)((char*)sv_ + pitch * 11) + threadID_);
+     real sg    = *((real*)((char*)sv_ + pitch * 12) + threadID_);
+     real Cai   = *((real*)((char*)sv_ + pitch * 13) + threadID_);
+     real CaSR  = *((real*)((char*)sv_ + pitch * 14) + threadID_);
+     real Nai   = *((real*)((char*)sv_ + pitch * 15) + threadID_);
+     real Ki    = *((real*)((char*)sv_ + pitch * 16) + threadID_);
+
+    //External concentrations
+    real Ko=5.4;
+    real Cao=2.0;
+    real Nao=140.0;
+
+    //Intracellular volumes
+    real Vc=0.016404;
+    real Vsr=0.001094;
+
+    //Calcium dynamics
+    real Bufc=0.15f;
+    real Kbufc=0.001f;
+    real Bufsr=10.f;
+    real Kbufsr=0.3f;
+    real taufca=2.f;
+    real taug=2.f;
+    real Vmaxup=0.000425f;
+    real Kup=0.00025f;
+
+    //Constants
+    const real R = 8314.472f;
+    const real F = 96485.3415f;
+    const real T =310.0f;
+    real RTONF   =(R*T)/F;
+
+    //Cellular capacitance         
+    real CAPACITANCE=0.185;
+
+    //Parameters for currents
+    //Parameters for IKr
+    real Gkr=0.096;
+    //Parameters for Iks
+    real pKNa=0.03;
+    // [!] Epicardium cell
+    real Gks=0.245;
+    //Parameters for Ik1
+    real GK1=5.405;
+    //Parameters for Ito
+// [!] Epicardium cell
+    real Gto=0.294;
+//Parameters for INa
+    real GNa=14.838;
+//Parameters for IbNa
+    real GbNa=0.00029;
+//Parameters for INaK
+    real KmK=1.0;
+    real KmNa=40.0;
+    real knak=1.362;
+//Parameters for ICaL
+    real GCaL=0.000175;
+//Parameters for IbCa
+    real GbCa=0.000592;
+//Parameters for INaCa
+    real knaca=1000;
+    real KmNai=87.5;
+    real KmCa=1.38;
+    real ksat=0.1;
+    real n=0.35;
+//Parameters for IpCa
+    real GpCa=0.825;
+    real KpCa=0.0005;
+//Parameters for IpK;
+    real GpK=0.0146;
+
+
+    real IKr;
+    real IKs;
+    real IK1;
+    real Ito;
+    real INa;
+    real IbNa;
+    real ICaL;
+    real IbCa;
+    real INaCa;
+    real IpCa;
+    real IpK;
+    real INaK;
+    real Irel;
+    real Ileak;
+
+
+    real dNai;
+    real dKi;
+    real dCai;
+    real dCaSR;
+
+    real A;
+//    real BufferFactorc;
+//    real BufferFactorsr;
+    real SERCA;
+    real Caisquare;
+    real CaSRsquare;
+    real CaCurrent;
+    real CaSRCurrent;
+
+
+    real fcaold;
+    real gold;
+    real Ek;
+    real Ena;
+    real Eks;
+    real Eca;
+    real CaCSQN;
+    real bjsr;
+    real cjsr;
+    real CaBuf;
+    real bc;
+    real cc;
+    real Ak1;
+    real Bk1;
+    real rec_iK1;
+    real rec_ipK;
+    real rec_iNaK;
+    real AM;
+    real BM;
+    real AH_1;
+    real BH_1;
+    real AH_2;
+    real BH_2;
+    real AJ_1;
+    real BJ_1;
+    real AJ_2;
+    real BJ_2;
+    real M_INF;
+    real H_INF;
+    real J_INF;
+    real TAU_M;
+    real TAU_H;
+    real TAU_J;
+    real axr1;
+    real bxr1;
+    real axr2;
+    real bxr2;
+    real Xr1_INF;
+    real Xr2_INF;
+    real TAU_Xr1;
+    real TAU_Xr2;
+    real Axs;
+    real Bxs;
+    real Xs_INF;
+    real TAU_Xs;
+    real R_INF;
+    real TAU_R;
+    real S_INF;
+    real TAU_S;
+    real Ad;
+    real Bd;
+    real Cd;
+    real TAU_D;
+    real D_INF;
+    real TAU_F;
+    real F_INF;
+    real FCa_INF;
+    real G_INF;
+
+    real inverseVcF2=1/(2*Vc*F);
+    real inverseVcF=1./(Vc*F);
+    real Kupsquare=Kup*Kup;
+//    real BufcKbufc=Bufc*Kbufc;
+//    real Kbufcsquare=Kbufc*Kbufc;
+//    real Kbufc2=2*Kbufc;
+//    real BufsrKbufsr=Bufsr*Kbufsr;
+//    const real Kbufsrsquare=Kbufsr*Kbufsr;
+//    const real Kbufsr2=2*Kbufsr;
+    const real exptaufca=exp(-dt/taufca);
+    const real exptaug=exp(-dt/taug);
+
+    real sItot;
+
+    //Needed to compute currents
+    Ek=RTONF*(log((Ko/Ki)));
+    Ena=RTONF*(log((Nao/Nai)));
+    Eks=RTONF*(log((Ko+pKNa*Nao)/(Ki+pKNa*Nai)));
+    Eca=0.5*RTONF*(log((Cao/Cai)));
+    Ak1=0.1/(1.+exp(0.06*(svolt-Ek-200)));
+    Bk1=(3.*exp(0.0002*(svolt-Ek+100))+
+         exp(0.1*(svolt-Ek-10)))/(1.+exp(-0.5*(svolt-Ek)));
+    rec_iK1=Ak1/(Ak1+Bk1);
+    rec_iNaK=(1./(1.+0.1245*exp(-0.1*svolt*F/(R*T))+0.0353*exp(-svolt*F/(R*T))));
+    rec_ipK=1./(1.+exp((25-svolt)/5.98));
+
+
+    //Compute currents
+    INa=GNa*sm*sm*sm*sh*sj*(svolt-Ena);
+    ICaL=GCaL*sd*sf*sfca*4*svolt*(F*F/(R*T))*
+         (exp(2*svolt*F/(R*T))*Cai-0.341*Cao)/(exp(2*svolt*F/(R*T))-1.);
+    Ito=Gto*sr*ss*(svolt-Ek);
+    IKr=Gkr*sqrt(Ko/5.4)*sxr1*sxr2*(svolt-Ek);
+    IKs=Gks*sxs*sxs*(svolt-Eks);
+    IK1=GK1*rec_iK1*(svolt-Ek);
+    INaCa=knaca*(1./(KmNai*KmNai*KmNai+Nao*Nao*Nao))*(1./(KmCa+Cao))*
+          (1./(1+ksat*exp((n-1)*svolt*F/(R*T))))*
+          (exp(n*svolt*F/(R*T))*Nai*Nai*Nai*Cao-
+           exp((n-1)*svolt*F/(R*T))*Nao*Nao*Nao*Cai*2.5);
+    INaK=knak*(Ko/(Ko+KmK))*(Nai/(Nai+KmNa))*rec_iNaK;
+    IpCa=GpCa*Cai/(KpCa+Cai);
+    IpK=GpK*rec_ipK*(svolt-Ek);
+    IbNa=GbNa*(svolt-Ena);
+    IbCa=GbCa*(svolt-Eca);
+
+
+    //Determine total current
+    (sItot) = IKr    +
+              IKs   +
+              IK1   +
+              Ito   +
+              INa   +
+              IbNa  +
+              ICaL  +
+              IbCa  +
+              INaK  +
+              INaCa +
+              IpCa  +
+              IpK   +
+              stim_current;
+
+
+    //update concentrations
+    Caisquare=Cai*Cai;
+    CaSRsquare=CaSR*CaSR;
+    CaCurrent=-(ICaL+IbCa+IpCa-2.0f*INaCa)*inverseVcF2*CAPACITANCE;
+    A=0.016464f*CaSRsquare/(0.0625f+CaSRsquare)+0.008232f;
+    Irel=A*sd*sg;
+    Ileak=0.00008f*(CaSR-Cai);
+    SERCA=Vmaxup/(1.f+(Kupsquare/Caisquare));
+    CaSRCurrent=SERCA-Irel-Ileak;
+    CaCSQN=Bufsr*CaSR/(CaSR+Kbufsr);
+    dCaSR=dt*(Vc/Vsr)*CaSRCurrent;
+    bjsr=Bufsr-CaCSQN-dCaSR-CaSR+Kbufsr;
+    cjsr=Kbufsr*(CaCSQN+dCaSR+CaSR);
+    CaSR=(sqrt(bjsr*bjsr+4.*cjsr)-bjsr)/2.;
+    CaBuf=Bufc*Cai/(Cai+Kbufc);
+    dCai=dt*(CaCurrent-CaSRCurrent);
+    bc=Bufc-CaBuf-dCai-Cai+Kbufc;
+    cc=Kbufc*(CaBuf+dCai+Cai);
+    Cai=(sqrt(bc*bc+4*cc)-bc)/2;
+
+
+
+    dNai=-(INa+IbNa+3*INaK+3*INaCa)*inverseVcF*CAPACITANCE;
+    Nai+=dt*dNai;
+
+    dKi=-(stim_current+IK1+Ito+IKr+IKs-2*INaK+IpK)*inverseVcF*CAPACITANCE;
+    Ki+=dt*dKi;
+
+    //compute steady state values and time constants
+    AM=1./(1.+exp((-60.-svolt)/5.));
+    BM=0.1/(1.+exp((svolt+35.)/5.))+0.10/(1.+exp((svolt-50.)/200.));
+    TAU_M=AM*BM;
+    M_INF=1./((1.+exp((-56.86-svolt)/9.03))*(1.+exp((-56.86-svolt)/9.03)));
+    if (svolt>=-40.)
+    {
+        AH_1=0.;
+        BH_1=(0.77/(0.13*(1.+exp(-(svolt+10.66)/11.1))));
+        TAU_H= 1.0/(AH_1+BH_1);
+    }
+    else
+    {
+        AH_2=(0.057*exp(-(svolt+80.)/6.8));
+        BH_2=(2.7*exp(0.079*svolt)+(3.1e5)*exp(0.3485*svolt));
+        TAU_H=1.0/(AH_2+BH_2);
+    }
+    H_INF=1./((1.+exp((svolt+71.55)/7.43))*(1.+exp((svolt+71.55)/7.43)));
+    if(svolt>=-40.)
+    {
+        AJ_1=0.;
+        BJ_1=(0.6*exp((0.057)*svolt)/(1.+exp(-0.1*(svolt+32.))));
+        TAU_J= 1.0/(AJ_1+BJ_1);
+    }
+    else
+    {
+        AJ_2=(((-2.5428e4)*exp(0.2444*svolt)-(6.948e-6)*
+                                             exp(-0.04391*svolt))*(svolt+37.78)/
+              (1.+exp(0.311*(svolt+79.23))));
+        BJ_2=(0.02424*exp(-0.01052*svolt)/(1.+exp(-0.1378*(svolt+40.14))));
+        TAU_J= 1.0/(AJ_2+BJ_2);
+    }
+    J_INF=H_INF;
+
+    Xr1_INF=1./(1.+exp((-26.-svolt)/7.));
+    axr1=450./(1.+exp((-45.-svolt)/10.));
+    bxr1=6./(1.+exp((svolt-(-30.))/11.5));
+    TAU_Xr1=axr1*bxr1;
+    Xr2_INF=1./(1.+exp((svolt-(-88.))/24.));
+    axr2=3./(1.+exp((-60.-svolt)/20.));
+    bxr2=1.12/(1.+exp((svolt-60.)/20.));
+    TAU_Xr2=axr2*bxr2;
+
+    Xs_INF=1./(1.+exp((-5.-svolt)/14.));
+    Axs=1100./(sqrt(1.+exp((-10.-svolt)/6)));
+    Bxs=1./(1.+exp((svolt-60.)/20.));
+    TAU_Xs=Axs*Bxs;
+
+    R_INF=1./(1.+exp((20-svolt)/6.));
+    S_INF=1./(1.+exp((svolt+20)/5.));
+    TAU_R=9.5*exp(-(svolt+40.)*(svolt+40.)/1800.)+0.8;
+    TAU_S=85.*exp(-(svolt+45.)*(svolt+45.)/320.)+5./(1.+exp((svolt-20.)/5.))+3.;
+
+
+    D_INF=1./(1.+exp((-5-svolt)/7.5));
+    Ad=1.4/(1.+exp((-35-svolt)/13))+0.25;
+    Bd=1.4/(1.+exp((svolt+5)/5));
+    Cd=1./(1.+exp((50-svolt)/20));
+    TAU_D=Ad*Bd+Cd;
+    F_INF=1./(1.+exp((svolt+20)/7));
+    TAU_F=1125*exp(-(svolt+27)*(svolt+27)/300)+80+165/(1.+exp((25-svolt)/10));
+
+
+    FCa_INF=(1./(1.+pow((Cai/0.000325),8))+
+             0.1/(1.+exp((Cai-0.0005)/0.0001))+
+             0.20/(1.+exp((Cai-0.00075)/0.0008))+
+             0.23 )/1.46;
+    if(Cai<0.00035)
+        G_INF=1./(1.+pow((Cai/0.00035),6));
+    else
+        G_INF=1./(1.+pow((Cai/0.00035),16));
+
+    //Update gates
+    rDY_[1]  = M_INF-(M_INF-sm)*exp(-dt/TAU_M);
+    rDY_[2]  = H_INF-(H_INF-sh)*exp(-dt/TAU_H);
+    rDY_[3]  = J_INF-(J_INF-sj)*exp(-dt/TAU_J);
+    rDY_[4]  = Xr1_INF-(Xr1_INF-sxr1)*exp(-dt/TAU_Xr1);
+    rDY_[5]  = Xr2_INF-(Xr2_INF-sxr2)*exp(-dt/TAU_Xr2);
+    rDY_[6]  = Xs_INF-(Xs_INF-sxs)*exp(-dt/TAU_Xs);
+    rDY_[7]  = S_INF-(S_INF-ss)*exp(-dt/TAU_S);
+    rDY_[8]  = R_INF-(R_INF-sr)*exp(-dt/TAU_R);
+    rDY_[9]  = D_INF-(D_INF-sd)*exp(-dt/TAU_D);
+    rDY_[10] = F_INF-(F_INF-sf)*exp(-dt/TAU_F);
+    fcaold= sfca;
+    sfca = FCa_INF-(FCa_INF-sfca)*exptaufca;
+    if(sfca>fcaold && (svolt)>-37.0)
+        sfca = fcaold;
+    gold = sg;
+    sg = G_INF-(G_INF-sg)*exptaug;
+
+    if(sg>gold && (svolt)>-37.0)
+        sg=gold;
+
+    //update voltage
+    rDY_[0] = svolt + dt*(-sItot);
+    rDY_[11] = sfca;
+    rDY_[12] = sg;
+    rDY_[13] = Cai;
+    rDY_[14] = CaSR;
+    rDY_[15] = Nai;
+    rDY_[16] = Ki;    
+
+}
+

--- a/src/models_library/ten_tusscher/mixed_tentusscher_myo_epi_2004.h
+++ b/src/models_library/ten_tusscher/mixed_tentusscher_myo_epi_2004.h
@@ -1,0 +1,40 @@
+#ifndef MONOALG3D_MIXED_MODEL_TEN_TUSSCHER_MYO_EPI_2004_H
+#define MONOALG3D_MIXED_MODEL_TEN_TUSSCHER_MYO_EPI_2004_H
+
+// Model 1 = TenTusscher 2004 myocardium
+// Model 2 = TenTusscher 2004 epicardium
+
+#include <stdint.h>
+#include "../model_common.h"
+
+#define NEQ 17
+#define INITIAL_V (-86.2f)
+
+#ifdef __CUDACC__
+
+#include "../../gpu_utils/gpu_utils.h"
+
+extern "C" {
+    #include "../../utils/file_utils.h"
+}
+
+__global__ void kernel_set_model_inital_conditions(real *sv, uint32_t *mapping, int num_volumes);
+
+__global__ void solve_gpu(real dt, real *sv, real* stim_currents,
+                          uint32_t *cells_to_solve, uint32_t *mapping, uint32_t num_cells_to_solve,
+                          int num_steps);
+
+inline __device__ void RHS_gpu_myo(real *sv_, real *rDY_, real stim_current, int threadID_, real dt);
+inline __device__ void RHS_gpu_epi(real *sv_, real *rDY_, real stim_current, int threadID_, real dt);
+
+#else
+#include "../../utils/file_utils.h"
+#endif
+
+void solve_model_ode_cpu_myo(real dt, real *sv, real stim_current);
+void RHS_cpu_myo(const real *sv, real *rDY_, real stim_current, real dt);
+
+void solve_model_ode_cpu_epi(real dt, real *sv, real stim_current);
+void RHS_cpu_epi(const real *sv, real *rDY_, real stim_current, real dt);
+
+#endif // MONOALG3D_MIXED_MODEL_TEN_TUSSCHER_MYO_EPI_2004_H

--- a/src/models_library/ten_tusscher/ten_tusscher_2004_RS_GPU.cu
+++ b/src/models_library/ten_tusscher/ten_tusscher_2004_RS_GPU.cu
@@ -119,8 +119,6 @@ __global__ void solve_gpu(real dt, real *sv, real* stim_currents,
 
             RHS_gpu(sv, rDY, stim_currents[threadID], sv_id, dt);
 
-            *((real*)((char*)sv) + sv_id) = dt*rDY[0] + *((real*)((char*)sv) + sv_id);
-
             for(int i = 0; i < NEQ; i++) {
                 *((real*)((char*)sv + pitch * i) + sv_id) = rDY[i];
             }

--- a/src/models_library/ten_tusscher/ten_tusscher_2004_mixed_endo_mid_epi.c
+++ b/src/models_library/ten_tusscher/ten_tusscher_2004_mixed_endo_mid_epi.c
@@ -1,0 +1,118 @@
+#include <assert.h>
+#include <stdlib.h>
+#include "ten_tusscher_2004_mixed_endo_mid_epi.h"
+
+
+GET_CELL_MODEL_DATA(init_cell_model_data) {
+
+    assert(cell_model);
+
+    if(get_initial_v)
+        cell_model->initial_v = INITIAL_V;
+    if(get_neq)
+        cell_model->number_of_ode_equations = NEQ;
+
+}
+
+SET_ODE_INITIAL_CONDITIONS_CPU(set_model_initial_conditions_cpu) {
+
+    uint32_t num_cells = solver->original_num_cells;
+	solver->sv = (real*)malloc(NEQ*num_cells*sizeof(real));
+
+    OMP(parallel for)
+    for(uint32_t i = 0; i < num_cells; i++) {
+
+        real *sv = &solver->sv[i * NEQ];
+
+        sv[0] = INITIAL_V; // V;       millivolt
+        sv[1] = 0.f;       // M
+        sv[2] = 0.75;      // H
+        sv[3] = 0.75f;     // J
+        sv[4] = 0.f;       // Xr1
+        sv[5] = 1.f;       // Xr2
+        sv[6] = 0.f;       // Xs
+        sv[7] = 1.f;       // S
+        sv[8] = 0.f;       // R
+        sv[9] = 0.f;       // D
+        sv[10] = 1.f;      // F
+        sv[11] = 1.f;      // FCa
+        sv[12] = 1.f;      // G
+        sv[13] = 0.0002;   // Cai
+        sv[14] = 0.2f;     // CaSR
+        sv[15] = 11.6f;    // Nai
+        sv[16] = 138.3f;   // Ki
+    }
+}
+
+SOLVE_MODEL_ODES(solve_model_odes_cpu) {
+
+    uint32_t sv_id;
+    int i;
+
+    size_t num_cells_to_solve = ode_solver->num_cells_to_solve;
+
+
+    // Get the mapping array
+    uint32_t *mapping = NULL;
+    if(ode_solver->ode_extra_data) {
+        mapping = (uint32_t*)ode_solver->ode_extra_data;
+    }
+    else {
+        log_to_stderr_and_file_and_exit("You need to specify a mask function when using this mixed model!\n");
+    }
+
+
+    OMP(parallel for private(sv_id))
+    for (i = 0; i < num_cells_to_solve; i++) {
+
+        if(ode_solver->cells_to_solve)
+            sv_id = ode_solver->cells_to_solve[i];
+        else
+            sv_id = i;
+
+        for (int j = 0; j < ode_solver->num_steps; ++j) {
+            solve_model_ode_cpu(ode_solver->min_dt, ode_solver->sv + (sv_id * NEQ), stim_currents[i], mapping[i]);
+        }
+    }
+}
+
+void solve_model_ode_cpu(real dt, real *sv, real stim_current, int mapping)  {
+
+    assert(sv);
+
+    real rY[NEQ], rDY[NEQ];
+
+    for(int i = 0; i < NEQ; i++)
+        rY[i] = sv[i];
+
+    RHS_cpu(rY, rDY, stim_current, dt, mapping);
+
+    for(int i = 0; i < NEQ; i++)
+        sv[i] = rDY[i];
+}
+
+
+void RHS_cpu(const real *sv, real *rDY_, real stim_current, real dt, int mapping) {
+
+    // State variables
+    real svolt = sv[0];
+    real sm    = sv[1];
+    real sh    = sv[2];
+    real sj    = sv[3];
+    real sxr1  = sv[4];
+    real sxr2  = sv[5];
+    real sxs   = sv[6];
+    real ss    = sv[7];
+    real sr    = sv[8];
+    real sd    = sv[9];
+    real sf    = sv[10];
+    real sfca  = sv[11];
+    real sg    = sv[12];
+    real Cai   = sv[13];
+    real CaSR  = sv[14];
+    real Nai   = sv[15];
+    real Ki    = sv[16];
+
+	#include "ten_tusscher_2004_mixed_endo_mid_epi.common.c"
+
+}

--- a/src/models_library/ten_tusscher/ten_tusscher_2004_mixed_endo_mid_epi.common.c
+++ b/src/models_library/ten_tusscher/ten_tusscher_2004_mixed_endo_mid_epi.common.c
@@ -1,0 +1,353 @@
+    //External concentrations
+    real Ko=5.4;
+    real Cao=2.0;
+    real Nao=140.0;
+
+    //Intracellular volumes
+    real Vc=0.016404;
+    real Vsr=0.001094;
+
+    //Calcium dynamics
+    real Bufc=0.15f;
+    real Kbufc=0.001f;
+    real Bufsr=10.f;
+    real Kbufsr=0.3f;
+    real taufca=2.f;
+    real taug=2.f;
+    real Vmaxup=0.000425f;
+    real Kup=0.00025f;
+
+//Constants
+    const real R = 8314.472f;
+    const real F = 96485.3415f;
+    const real T =310.0f;
+    real RTONF   =(R*T)/F;
+
+//Cellular capacitance         
+    real CAPACITANCE=0.185;
+
+	//Parameters for currents
+	//Parameters for IKr
+    real Gkr=0.096;
+	//Parameters for Iks
+    real pKNa=0.03;
+	
+	//default is EPI
+    real Gks=0.245;
+
+	if (mapping == ENDO || mapping == MID)
+    	Gks=0.245;
+
+	//Parameters for Ik1
+    real GK1=5.405;
+
+	//Parameters for Ito
+    real Gto=0.294;
+
+	if (mapping == ENDO || mapping == MID)
+    	Gto=0.073;
+
+	//Parameters for INa
+    real GNa=14.838;
+//Parameters for IbNa
+    real GbNa=0.00029;
+//Parameters for INaK
+    real KmK=1.0;
+    real KmNa=40.0;
+    real knak=1.362;
+//Parameters for ICaL
+    real GCaL=0.000175;
+//Parameters for IbCa
+    real GbCa=0.000592;
+//Parameters for INaCa
+    real knaca=1000;
+    real KmNai=87.5;
+    real KmCa=1.38;
+    real ksat=0.1;
+    real n=0.35;
+//Parameters for IpCa
+    real GpCa=0.825;
+    real KpCa=0.0005;
+//Parameters for IpK;
+    real GpK=0.0146;
+
+
+    real IKr;
+    real IKs;
+    real IK1;
+    real Ito;
+    real INa;
+    real IbNa;
+    real ICaL;
+    real IbCa;
+    real INaCa;
+    real IpCa;
+    real IpK;
+    real INaK;
+    real Irel;
+    real Ileak;
+
+
+    real dNai;
+    real dKi;
+    real dCai;
+    real dCaSR;
+
+    real A;
+    real SERCA;
+    real Caisquare;
+    real CaSRsquare;
+    real CaCurrent;
+    real CaSRCurrent;
+
+
+    real fcaold;
+    real gold;
+    real Ek;
+    real Ena;
+    real Eks;
+    real Eca;
+    real CaCSQN;
+    real bjsr;
+    real cjsr;
+    real CaBuf;
+    real bc;
+    real cc;
+    real Ak1;
+    real Bk1;
+    real rec_iK1;
+    real rec_ipK;
+    real rec_iNaK;
+    real AM;
+    real BM;
+    real AH_1;
+    real BH_1;
+    real AH_2;
+    real BH_2;
+    real AJ_1;
+    real BJ_1;
+    real AJ_2;
+    real BJ_2;
+    real M_INF;
+    real H_INF;
+    real J_INF;
+    real TAU_M;
+    real TAU_H;
+    real TAU_J;
+    real axr1;
+    real bxr1;
+    real axr2;
+    real bxr2;
+    real Xr1_INF;
+    real Xr2_INF;
+    real TAU_Xr1;
+    real TAU_Xr2;
+    real Axs;
+    real Bxs;
+    real Xs_INF;
+    real TAU_Xs;
+    real R_INF;
+    real TAU_R;
+    real S_INF;
+    real TAU_S;
+    real Ad;
+    real Bd;
+    real Cd;
+    real TAU_D;
+    real D_INF;
+    real TAU_F;
+    real F_INF;
+    real FCa_INF;
+    real G_INF;
+
+    real inverseVcF2=1/(2*Vc*F);
+    real inverseVcF=1./(Vc*F);
+    real Kupsquare=Kup*Kup;
+    const real exptaufca=exp(-dt/taufca);
+    const real exptaug=exp(-dt/taug);
+
+    real sItot;
+
+    //Needed to compute currents
+    Ek=RTONF*(log((Ko/Ki)));
+    Ena=RTONF*(log((Nao/Nai)));
+    Eks=RTONF*(log((Ko+pKNa*Nao)/(Ki+pKNa*Nai)));
+    Eca=0.5*RTONF*(log((Cao/Cai)));
+    Ak1=0.1/(1.+exp(0.06*(svolt-Ek-200)));
+    Bk1=(3.*exp(0.0002*(svolt-Ek+100))+
+         exp(0.1*(svolt-Ek-10)))/(1.+exp(-0.5*(svolt-Ek)));
+    rec_iK1=Ak1/(Ak1+Bk1);
+    rec_iNaK=(1./(1.+0.1245*exp(-0.1*svolt*F/(R*T))+0.0353*exp(-svolt*F/(R*T))));
+    rec_ipK=1./(1.+exp((25-svolt)/5.98));
+
+
+    //Compute currents
+    INa=GNa*sm*sm*sm*sh*sj*(svolt-Ena);
+    ICaL=GCaL*sd*sf*sfca*4*svolt*(F*F/(R*T))*
+         (exp(2*svolt*F/(R*T))*Cai-0.341*Cao)/(exp(2*svolt*F/(R*T))-1.);
+    Ito=Gto*sr*ss*(svolt-Ek);
+    IKr=Gkr*sqrt(Ko/5.4)*sxr1*sxr2*(svolt-Ek);
+    IKs=Gks*sxs*sxs*(svolt-Eks);
+    IK1=GK1*rec_iK1*(svolt-Ek);
+    INaCa=knaca*(1./(KmNai*KmNai*KmNai+Nao*Nao*Nao))*(1./(KmCa+Cao))*
+          (1./(1+ksat*exp((n-1)*svolt*F/(R*T))))*
+          (exp(n*svolt*F/(R*T))*Nai*Nai*Nai*Cao-
+           exp((n-1)*svolt*F/(R*T))*Nao*Nao*Nao*Cai*2.5);
+    INaK=knak*(Ko/(Ko+KmK))*(Nai/(Nai+KmNa))*rec_iNaK;
+    IpCa=GpCa*Cai/(KpCa+Cai);
+    IpK=GpK*rec_ipK*(svolt-Ek);
+    IbNa=GbNa*(svolt-Ena);
+    IbCa=GbCa*(svolt-Eca);
+
+
+    //Determine total current
+    (sItot) = IKr    +
+              IKs   +
+              IK1   +
+              Ito   +
+              INa   +
+              IbNa  +
+              ICaL  +
+              IbCa  +
+              INaK  +
+              INaCa +
+              IpCa  +
+              IpK   +
+              stim_current;
+
+
+    //update concentrations
+    Caisquare=Cai*Cai;
+    CaSRsquare=CaSR*CaSR;
+    CaCurrent=-(ICaL+IbCa+IpCa-2.0f*INaCa)*inverseVcF2*CAPACITANCE;
+    A=0.016464f*CaSRsquare/(0.0625f+CaSRsquare)+0.008232f;
+    Irel=A*sd*sg;
+    Ileak=0.00008f*(CaSR-Cai);
+    SERCA=Vmaxup/(1.f+(Kupsquare/Caisquare));
+    CaSRCurrent=SERCA-Irel-Ileak;
+    CaCSQN=Bufsr*CaSR/(CaSR+Kbufsr);
+    dCaSR=dt*(Vc/Vsr)*CaSRCurrent;
+    bjsr=Bufsr-CaCSQN-dCaSR-CaSR+Kbufsr;
+    cjsr=Kbufsr*(CaCSQN+dCaSR+CaSR);
+    CaSR=(sqrt(bjsr*bjsr+4.*cjsr)-bjsr)/2.;
+    CaBuf=Bufc*Cai/(Cai+Kbufc);
+    dCai=dt*(CaCurrent-CaSRCurrent);
+    bc=Bufc-CaBuf-dCai-Cai+Kbufc;
+    cc=Kbufc*(CaBuf+dCai+Cai);
+    Cai=(sqrt(bc*bc+4*cc)-bc)/2;
+
+    dNai=-(INa+IbNa+3*INaK+3*INaCa)*inverseVcF*CAPACITANCE;
+    Nai+=dt*dNai;
+
+    dKi=-(stim_current+IK1+Ito+IKr+IKs-2*INaK+IpK)*inverseVcF*CAPACITANCE;
+    Ki+=dt*dKi;
+
+    //compute steady state values and time constants
+    AM=1./(1.+exp((-60.-svolt)/5.));
+    BM=0.1/(1.+exp((svolt+35.)/5.))+0.10/(1.+exp((svolt-50.)/200.));
+    TAU_M=AM*BM;
+    M_INF=1./((1.+exp((-56.86-svolt)/9.03))*(1.+exp((-56.86-svolt)/9.03)));
+    if (svolt>=-40.)
+    {
+        AH_1=0.;
+        BH_1=(0.77/(0.13*(1.+exp(-(svolt+10.66)/11.1))));
+        TAU_H= 1.0/(AH_1+BH_1);
+    }
+    else
+    {
+        AH_2=(0.057*exp(-(svolt+80.)/6.8));
+        BH_2=(2.7*exp(0.079*svolt)+(3.1e5)*exp(0.3485*svolt));
+        TAU_H=1.0/(AH_2+BH_2);
+    }
+    H_INF=1./((1.+exp((svolt+71.55)/7.43))*(1.+exp((svolt+71.55)/7.43)));
+    if(svolt>=-40.)
+    {
+        AJ_1=0.;
+        BJ_1=(0.6*exp((0.057)*svolt)/(1.+exp(-0.1*(svolt+32.))));
+        TAU_J= 1.0/(AJ_1+BJ_1);
+    }
+    else
+    {
+        AJ_2=(((-2.5428e4)*exp(0.2444*svolt)-(6.948e-6)*
+                                             exp(-0.04391*svolt))*(svolt+37.78)/
+              (1.+exp(0.311*(svolt+79.23))));
+        BJ_2=(0.02424*exp(-0.01052*svolt)/(1.+exp(-0.1378*(svolt+40.14))));
+        TAU_J= 1.0/(AJ_2+BJ_2);
+    }
+    J_INF=H_INF;
+
+    Xr1_INF=1./(1.+exp((-26.-svolt)/7.));
+    axr1=450./(1.+exp((-45.-svolt)/10.));
+    bxr1=6./(1.+exp((svolt-(-30.))/11.5));
+    TAU_Xr1=axr1*bxr1;
+    Xr2_INF=1./(1.+exp((svolt-(-88.))/24.));
+    axr2=3./(1.+exp((-60.-svolt)/20.));
+    bxr2=1.12/(1.+exp((svolt-60.)/20.));
+    TAU_Xr2=axr2*bxr2;
+
+    Xs_INF=1./(1.+exp((-5.-svolt)/14.));
+    Axs=1100./(sqrt(1.+exp((-10.-svolt)/6)));
+    Bxs=1./(1.+exp((svolt-60.)/20.));
+    TAU_Xs=Axs*Bxs;
+
+	if(mapping == EPI) {
+		R_INF=1./(1.+exp((20-svolt)/6.));
+		S_INF=1./(1.+exp((svolt+20)/5.));
+		TAU_R=9.5*exp(-(svolt+40.)*(svolt+40.)/1800.)+0.8;
+		TAU_S=85.*exp(-(svolt+45.)*(svolt+45.)/320.)+5./(1.+exp((svolt-20.)/5.))+3.;
+	}
+	else if(mapping == ENDO || mapping == MID) {
+		R_INF=1./(1.+exp((20-svolt)/6.));
+		S_INF=1./(1.+exp((svolt+28)/5.));
+		TAU_R=9.5*exp(-(svolt+40.)*(svolt+40.)/1800.)+0.8;
+		TAU_S=1000.*exp(-(svolt+67)*(svolt+67)/1000.)+8.;
+	}
+
+    D_INF=1./(1.+exp((-5-svolt)/7.5));
+    Ad=1.4/(1.+exp((-35-svolt)/13))+0.25;
+    Bd=1.4/(1.+exp((svolt+5)/5));
+    Cd=1./(1.+exp((50-svolt)/20));
+    TAU_D=Ad*Bd+Cd;
+    F_INF=1./(1.+exp((svolt+20)/7));
+    TAU_F=1125*exp(-(svolt+27)*(svolt+27)/300)+80+165/(1.+exp((25-svolt)/10));
+
+
+    FCa_INF=(1./(1.+pow((Cai/0.000325),8))+
+             0.1/(1.+exp((Cai-0.0005)/0.0001))+
+             0.20/(1.+exp((Cai-0.00075)/0.0008))+
+             0.23 )/1.46;
+    if(Cai<0.00035)
+        G_INF=1./(1.+pow((Cai/0.00035),6));
+    else
+        G_INF=1./(1.+pow((Cai/0.00035),16));
+
+    //Update gates
+    rDY_[1]  = M_INF-(M_INF-sm)*exp(-dt/TAU_M);
+    rDY_[2]  = H_INF-(H_INF-sh)*exp(-dt/TAU_H);
+    rDY_[3]  = J_INF-(J_INF-sj)*exp(-dt/TAU_J);
+    rDY_[4]  = Xr1_INF-(Xr1_INF-sxr1)*exp(-dt/TAU_Xr1);
+    rDY_[5]  = Xr2_INF-(Xr2_INF-sxr2)*exp(-dt/TAU_Xr2);
+    rDY_[6]  = Xs_INF-(Xs_INF-sxs)*exp(-dt/TAU_Xs);
+    rDY_[7]  = S_INF-(S_INF-ss)*exp(-dt/TAU_S);
+    rDY_[8]  = R_INF-(R_INF-sr)*exp(-dt/TAU_R);
+    rDY_[9]  = D_INF-(D_INF-sd)*exp(-dt/TAU_D);
+    rDY_[10] = F_INF-(F_INF-sf)*exp(-dt/TAU_F);
+    fcaold= sfca;
+    sfca = FCa_INF-(FCa_INF-sfca)*exptaufca;
+    if(sfca>fcaold && (svolt)>-37.0)
+        sfca = fcaold;
+    gold = sg;
+    sg = G_INF-(G_INF-sg)*exptaug;
+
+    if(sg>gold && (svolt)>-37.0)
+        sg=gold;
+
+    //update voltage
+    rDY_[0] = svolt + dt*(-sItot);
+    rDY_[11] = sfca;
+    rDY_[12] = sg;
+    rDY_[13] = Cai;
+    rDY_[14] = CaSR;
+    rDY_[15] = Nai;
+    rDY_[16] = Ki;
+

--- a/src/models_library/ten_tusscher/ten_tusscher_2004_mixed_endo_mid_epi.cu
+++ b/src/models_library/ten_tusscher/ten_tusscher_2004_mixed_endo_mid_epi.cu
@@ -1,0 +1,173 @@
+#include "../../gpu_utils/gpu_utils.h"
+#include <stddef.h>
+#include <stdint.h>
+
+#include "ten_tusscher_2004_mixed_endo_mid_epi.h"
+
+__constant__ size_t pitch;
+size_t pitch_h;
+
+extern "C" SET_ODE_INITIAL_CONDITIONS_GPU(set_model_initial_conditions_gpu) {
+
+    uint32_t num_volumes = solver->original_num_cells;
+
+    #ifdef ENDO
+        log_to_stdout_and_file("Using ten Tusscher 2004 ENDO GPU model\n");
+    #endif
+
+    #ifdef EPI
+        log_to_stdout_and_file("Using ten Tusscher 2004 EPI GPU model\n");
+    #endif
+
+    // execution configuration
+    const int GRID  = (num_volumes + BLOCK_SIZE - 1)/BLOCK_SIZE;
+
+    size_t size = num_volumes*sizeof(real);
+
+    check_cuda_error(cudaMallocPitch((void **) &(solver->sv), &pitch_h, size, (size_t )NEQ));
+    check_cuda_error(cudaMemcpyToSymbol(pitch, &pitch_h, sizeof(size_t)));
+
+    kernel_set_model_inital_conditions <<<GRID, BLOCK_SIZE>>>(solver->sv, num_volumes);
+
+    check_cuda_error( cudaPeekAtLastError() );
+    cudaDeviceSynchronize();
+    return pitch_h;
+
+}
+
+
+extern "C" SOLVE_MODEL_ODES(solve_model_odes_gpu) {
+
+    size_t num_cells_to_solve = ode_solver->num_cells_to_solve;
+    uint32_t * cells_to_solve = ode_solver->cells_to_solve;
+    real *sv = ode_solver->sv;
+    real dt = ode_solver->min_dt;
+    uint32_t num_steps = ode_solver->num_steps;
+
+    // execution configuration
+    const int GRID  = ((int)num_cells_to_solve + BLOCK_SIZE - 1)/BLOCK_SIZE;
+
+
+    size_t stim_currents_size = sizeof(real)*num_cells_to_solve;
+    size_t cells_to_solve_size = sizeof(uint32_t)*num_cells_to_solve;
+
+    real *stims_currents_device;
+    check_cuda_error(cudaMalloc((void **) &stims_currents_device, stim_currents_size));
+    check_cuda_error(cudaMemcpy(stims_currents_device, stim_currents, stim_currents_size, cudaMemcpyHostToDevice));
+
+
+    //the array cells to solve is passed when we are using and adapative mesh
+    uint32_t *cells_to_solve_device = NULL;
+    if(cells_to_solve != NULL) {
+        check_cuda_error(cudaMalloc((void **) &cells_to_solve_device, cells_to_solve_size));
+        check_cuda_error(cudaMemcpy(cells_to_solve_device, cells_to_solve, cells_to_solve_size, cudaMemcpyHostToDevice));
+    }
+
+	// Get the mapping array
+    uint32_t *mapping = NULL;
+    uint32_t *mapping_device = NULL;
+    if(ode_solver->ode_extra_data) 
+    {
+        mapping = (uint32_t*)ode_solver->ode_extra_data;
+        check_cuda_error(cudaMalloc((void **)&mapping_device, ode_solver->extra_data_size));
+        check_cuda_error(cudaMemcpy(mapping_device, mapping, ode_solver->extra_data_size, cudaMemcpyHostToDevice));
+    }
+    else 
+    {
+        log_to_stderr_and_file_and_exit("You need to specify a mask function when using a mixed model!\n");
+    }
+
+    solve_gpu <<<GRID, BLOCK_SIZE>>>(dt, sv, stims_currents_device, cells_to_solve_device, num_cells_to_solve, num_steps, mapping_device);
+
+    check_cuda_error( cudaPeekAtLastError() );
+
+    check_cuda_error(cudaFree(stims_currents_device));
+    if(cells_to_solve_device) check_cuda_error(cudaFree(cells_to_solve_device));
+    if(mapping_device) check_cuda_error(cudaFree(mapping_device));
+}
+
+__global__ void kernel_set_model_inital_conditions(real *sv, int num_volumes)
+{
+    // Thread ID
+    int threadID = blockDim.x * blockIdx.x + threadIdx.x;
+
+    if(threadID < num_volumes) {
+
+        *((real*)((char*)sv + pitch * 0) + threadID)  = INITIAL_V;   // V;       millivolt
+        *((real*)((char*)sv + pitch * 1) + threadID)  = 0.f;   //M
+        *((real*)((char*)sv + pitch * 2) + threadID)  = 0.75;    //H
+        *((real*)((char*)sv + pitch * 3) + threadID)  = 0.75f;    //J
+        *((real*)((char*)sv + pitch * 4) + threadID)  = 0.f;   //Xr1
+        *((real*)((char*)sv + pitch * 5) + threadID)  = 1.f;    //Xr2
+        *((real*)((char*)sv + pitch * 6) + threadID)  = 0.f;    //Xs
+        *((real*)((char*)sv + pitch * 7) + threadID)  = 1.f;  //S
+        *((real*)((char*)sv + pitch * 8) + threadID)  = 0.f;    //R
+        *((real*)((char*)sv + pitch * 9) + threadID)  = 0.f;    //D
+        *((real*)((char*)sv + pitch * 10) + threadID) = 1.f;   //F
+        *((real*)((char*)sv + pitch * 11) + threadID) = 1.f; //FCa
+        *((real*)((char*)sv + pitch * 12) + threadID) = 1.f;  //G
+        *((real*)((char*)sv + pitch * 13) + threadID) = 0.0002;  //Cai
+        *((real*)((char*)sv + pitch * 14) + threadID) = 0.2f;      //CaSR
+        *((real*)((char*)sv + pitch * 15) + threadID) = 11.6f;   //Nai
+        *((real*)((char*)sv + pitch * 16) + threadID) = 138.3f;    //Ki
+
+
+    }
+}
+
+
+// Solving the model for each cell in the tissue matrix ni x nj
+__global__ void solve_gpu(real dt, real *sv, real* stim_currents,                         
+						  uint32_t *cells_to_solve, uint32_t num_cells_to_solve,
+                          int num_steps, uint32_t *mapping)
+{
+    int threadID = blockDim.x * blockIdx.x + threadIdx.x;
+    int sv_id;
+
+    // Each thread solves one cell model
+    if(threadID < num_cells_to_solve) {
+        if(cells_to_solve)
+            sv_id = cells_to_solve[threadID];
+        else
+            sv_id = threadID;
+
+        real rDY[NEQ];
+
+        for (int n = 0; n < num_steps; ++n) {
+
+            RHS_gpu(sv, rDY, stim_currents[threadID], sv_id, dt, mapping[threadID]);
+
+            for(int i = 0; i < NEQ; i++) {
+                *((real*)((char*)sv + pitch * i) + sv_id) = rDY[i];
+            }
+            
+        }
+
+    }
+}
+
+
+inline __device__ void RHS_gpu(real *sv, real *rDY_, real stim_current, int threadID_, real dt, int mapping) {
+
+    // State variables
+    real svolt = *((real*)((char*)sv + pitch * 0) + threadID_);
+    real sm    = *((real*)((char*)sv + pitch * 1) + threadID_);
+    real sh    = *((real*)((char*)sv + pitch * 2) + threadID_);
+    real sj    = *((real*)((char*)sv + pitch * 3) + threadID_);
+    real sxr1  = *((real*)((char*)sv + pitch * 4) + threadID_);
+    real sxr2  = *((real*)((char*)sv + pitch * 5) + threadID_);
+    real sxs   = *((real*)((char*)sv + pitch * 6) + threadID_);
+    real ss    = *((real*)((char*)sv + pitch * 7) + threadID_);
+    real sr    = *((real*)((char*)sv + pitch * 8) + threadID_);
+    real sd    = *((real*)((char*)sv + pitch * 9) + threadID_);
+    real sf    = *((real*)((char*)sv + pitch * 10) + threadID_);
+    real sfca  = *((real*)((char*)sv + pitch * 11) + threadID_);
+    real sg    = *((real*)((char*)sv + pitch * 12) + threadID_);
+    real Cai   = *((real*)((char*)sv + pitch * 13) + threadID_);
+    real CaSR  = *((real*)((char*)sv + pitch * 14) + threadID_);
+    real Nai   = *((real*)((char*)sv + pitch * 15) + threadID_);
+    real Ki    = *((real*)((char*)sv + pitch * 16) + threadID_);
+
+	#include "ten_tusscher_2004_mixed_endo_mid_epi.common.c"
+    
+}

--- a/src/models_library/ten_tusscher/ten_tusscher_2004_mixed_endo_mid_epi.h
+++ b/src/models_library/ten_tusscher/ten_tusscher_2004_mixed_endo_mid_epi.h
@@ -1,0 +1,30 @@
+#ifndef MONOALG3D_MODEL_TEN_TUSSCHER_2004_H
+#define MONOALG3D_MODEL_TEN_TUSSCHER_2004_H
+
+#include "../model_common.h"
+#include <stdint.h>
+
+#define NEQ 17
+#define INITIAL_V (-86.2f)
+
+#define ENDO 0
+#define MID  1
+#define EPI  2
+
+
+#ifdef __CUDACC__
+
+__global__ void kernel_set_model_inital_conditions(real *sv, int num_volumes);
+
+__global__ void solve_gpu(real dt, real *sv, real* stim_currents,
+						  uint32_t *cells_to_solve, uint32_t num_cells_to_solve,
+                          int num_steps, uint32_t *mapping);
+
+inline __device__ void RHS_gpu(real *sv_, real *rDY_, real stim_current, int threadID_, real dt, int mapping);
+
+#endif
+
+void RHS_cpu(const real *sv, real *rDY_, real stim_current, real dt, int mapping);
+void solve_model_ode_cpu(real dt, real *sv, real stim_current, int mapping);
+
+#endif //MONOALG3D_MODEL_TEN_TUSSCHER_2004_H

--- a/src/ode_solver/ode_solver.c
+++ b/src/ode_solver/ode_solver.c
@@ -37,7 +37,7 @@ struct ode_solver* new_ode_solver() {
     result->model_data.model_library_path = NULL;
 
     result->ode_extra_data = NULL;
-    result->ode_extra_data = 0;
+    result->extra_data_size = 0;
     
     return result;
 

--- a/src/vtk_utils/vtk_unstructured_grid.h
+++ b/src/vtk_utils/vtk_unstructured_grid.h
@@ -90,8 +90,8 @@ void save_vtk_unstructured_grid_as_alg_file(struct vtk_unstructured_grid *vtk_gr
 void free_vtk_unstructured_grid(struct vtk_unstructured_grid *vtk_grid);
 
 struct vtk_unstructured_grid * new_vtk_unstructured_grid_from_file(const char *vtu_file_name);
-void new_vtk_unstructured_grid_from_string(struct vtk_unstructured_grid **vtk_grid, char* source, size_t source_size, bool binary, bool read_only_values);
+struct vtk_unstructured_grid * new_vtk_unstructured_grid_from_file_with_index(const char *file_name, uint32_t v_index);
+void new_vtk_unstructured_grid_from_string(struct vtk_unstructured_grid **vtk_grid, char* source, size_t source_size, bool binary, bool read_only_values, int v_index);
 void new_vtk_unstructured_grid_from_string_with_activation_info(struct vtk_unstructured_grid **vtk_grid, char* source, size_t source_size);
-void set_vtk_grid_from_file(struct vtk_unstructured_grid **vtk_grid, const char *file_name);
 
 #endif // MONOALG3D_VTK_UNSTRUCTURED_GRID_H


### PR DESCRIPTION
There are new functions for the atrial mesh example, which not only construct the grid, but also uses the mixed cellular library to configure the ENDO, EPI and MCELL flags of a given model. In addition, it is now possible to convert a heart mesh to the solver format directly on the code using new the 'converter' structure.